### PR TITLE
#33 Add support for non Drupal 8 projects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
         "squizlabs/php_codesniffer": "^3.4",
         "dealerdirect/phpcodesniffer-composer-installer": "*",
         "mglaman/phpstan-drupal": "^0.11.1",
-        "phpstan/phpstan-deprecation-rules": "^0.11.0"
+        "phpstan/phpstan-deprecation-rules": "^0.11.0",
+        "symfony/polyfill-iconv": "^1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Code Quality tool needs PHP iconv module enabled but
it's not always available by default. That's why
Drupal 8 has added polyfill package for it and it
makes sense to add it to Code Quality too. We want
this tool to be installed as easily as possible.