### PR TITLE
#33 Fix some iconv issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
     ],
     "bin": ["bin/check_perms"],
     "require": {
+        "symfony/polyfill-iconv": "^1",
         "phpro/grumphp": "^0.16.0",
         "drupal/coder": "^8",
         "phpcompatibility/php-compatibility": "^9.3",


### PR DESCRIPTION
PHP iconv extension is needed on the system for this plugin to work.
We'll add polyfill-iconv here in case you are working with Lando
and the plugin is available in Docker container but
git commit fails as the extension is not available in the
host system.