### PR TITLE
Phpstan update from 0.11 to 0.12 version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,8 @@
         "symplify/coding-standard": "^6.0",
         "squizlabs/php_codesniffer": "^3.4",
         "dealerdirect/phpcodesniffer-composer-installer": "*",
-        "mglaman/phpstan-drupal": "^0.11.1",
-        "phpstan/phpstan-deprecation-rules": "^0.11.0"
+        "mglaman/phpstan-drupal": "^0.12.2",
+        "phpstan/phpstan-deprecation-rules": "^0.12.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This is needed because the Drupal module upgrade status is using already a 0.12 version.