### PR TITLE
#47 Fix phpcs not using defined extensions.

### DIFF
--- a/src/Task/Phpcs/PhpcsTask.php
+++ b/src/Task/Phpcs/PhpcsTask.php
@@ -22,6 +22,7 @@ class PhpcsTask extends AbstractMultiPathProcessingTask {
     $config = $this->getConfiguration();
     $config['basepath'] = $config['basepath'] ?? '.';
     $arguments->addOptionalCommaSeparatedArgument('--standard=%s', (array) $config['standard']);
+    $arguments->addOptionalCommaSeparatedArgument('--extensions=%s', (array) $config['extensions']);
     $arguments->addOptionalArgument('--tab-width=%s', $config['tab_width']);
     $arguments->addOptionalArgument('--encoding=%s', $config['encoding']);
     $arguments->addOptionalArgument('--report=%s', $config['report']);


### PR DESCRIPTION
Quite easy fix. You can also see that it was still there in the original GrumpHP code:
https://github.com/phpro/grumphp/blob/master/src/Task/Phpcs.php

