### PR TITLE
Use %currentWorkingDirectory% while defining includes for default phpstan config

### DIFF
--- a/config/phpstan.neon
+++ b/config/phpstan.neon
@@ -8,9 +8,9 @@ parameters:
 		- '#Missing cache backend declaration for performance.#'
 		- '#Plugin manager has cache backend specified but does not declare cache tags.#'
 includes:
-	- vendor/mglaman/phpstan-drupal/extension.neon
-	- vendor/phpstan/phpstan-deprecation-rules/rules.neon
-	- vendor/symplify/coding-standard/packages/cognitive-complexity/config/cognitive-complexity-services.neon
+	- %currentWorkingDirectory%/vendor/mglaman/phpstan-drupal/extension.neon
+	- %currentWorkingDirectory%/vendor/phpstan/phpstan-deprecation-rules/rules.neon
+	- %currentWorkingDirectory%/vendor/symplify/coding-standard/packages/cognitive-complexity/config/cognitive-complexity-services.neon
 
 services:
     -


### PR DESCRIPTION
Sorry. Still one more small fix to add.

When loading default config for PHPStan from config/phpstan.neon, includes paths needs to start with %currentWorkingDirectory%/... in order to load them starting from project's root.

Otherwise error of "File 'xx/vendor/wunderio/code-quality/config/vendor/mglaman/phpstan-drupal/extension.neon' is missing or is not readable." shown.