### PR TITLE
Increase default process_timeout from 60 to 300

### DIFF
--- a/config/grumphp.yml
+++ b/config/grumphp.yml
@@ -1,5 +1,6 @@
 grumphp:
   stop_on_failure: true
+  process_timeout: 300
   ascii:
     failed: ~
     succeeded: ~


### PR DESCRIPTION
GrumPHP uses the Symfony Process component to run external tasks. The component will trigger a timeout after 60 seconds by default. 

In cases when custom code and/or module is added in commit, default timeout will be easily exceeded. Thus, proposing that we include process_timeout of 300 by default.

Example:

```
GrumPHP detected a pre-commit command.
GrumPHP is sniffing your code!

Running tasks with priority 0!
==============================

Running task 1/8: php_compatibility...
Running task 2/8: check_file_permissions...
Running task 3/8: php_check_syntax...
Running task 4/8: phpcs...
Running task 5/8: php_stan...
Running task 6/8: ecs...
Running task 7/8: yaml_lint...
Running task 8/8: json_lint...

Running task 1/8: php_compatibility... ✔
Running task 2/8: check_file_permissions...
Running task 3/8: php_check_syntax... ✔
Running task 4/8: phpcs... ✔
Running task 5/8: php_stan... ✘
Running task 6/8: ecs... ✔
Running task 7/8: yaml_lint... ✔
Running task 8/8: json_lint...


php_stan
========

The process "'/app/vendor/bin/phpstan' 'analyse' '--configuration=vendor/wunderio/code-quality/config/phpstan.neon' '--no-ansi' '--no-interaction' '--no-progress' 'web/modules/custom/omnia_webshop_reporting/omnia_webshop_reporting.module'" exceeded the timeout of 60 seconds.
To skip commit checks, add -n or --no-verify flag to commit command
```

