### PR TITLE
#62 Add Psalm support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ code by using https://github.com/phpro/grumphp.
 **It checks only modified files or new files on git commit, but check on all configured
 paths can be executed running `vendor/bin/grumphp run`**
 
-This tool only extends [GrumPHP](https://github.com/phpro/grumphp). Please read 
+This tool only extends [GrumPHP](https://github.com/phpro/grumphp). Please read
 its [documentation](https://github.com/phpro/grumphp/blob/master/README.md#configuration) on how to configure tool itself.
 
 ## Checks performed
@@ -37,6 +37,7 @@ This needs to be done only once either while creating a project or enabling code
 composer require wunderio/code-quality --dev
 cp vendor/wunderio/code-quality/config/grumphp.yml ./grumphp.yml
 cp vendor/wunderio/code-quality/config/phpstan.neon ./phpstan.neon
+cp vendor/wunderio/code-quality/config/psalm.xml ./psalm.xml
 ```
 
 The commit hook for GrumPHP is automatically installed on composer require.

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
         "squizlabs/php_codesniffer": "^3.4",
         "dealerdirect/phpcodesniffer-composer-installer": "*",
         "mglaman/phpstan-drupal": "^1.1",
-        "phpstan/phpstan-deprecation-rules": "^1.0"
+        "phpstan/phpstan-deprecation-rules": "^1.0",
+        "vimeo/psalm": "^4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -44,8 +44,7 @@
         "dealerdirect/phpcodesniffer-composer-installer": "*",
         "mglaman/phpstan-drupal": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",
-        "vimeo/psalm": "^4",
-        "fenetikm/autoload-drupal": "dev-master#4503484"
+        "vimeo/psalm": "^4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
         "dealerdirect/phpcodesniffer-composer-installer": "*",
         "mglaman/phpstan-drupal": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",
-        "vimeo/psalm": "^4"
+        "vimeo/psalm": "^4",
+        "fenetikm/autoload-drupal": "dev-master#4503484"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
         "dealerdirect/phpcodesniffer-composer-installer": "*",
         "mglaman/phpstan-drupal": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",
-        "vimeo/psalm": "^4"
+        "vimeo/psalm": "^4",
+        "nette/finder": "^2.5"
     },
     "autoload": {
         "psr-4": {

--- a/config/grumphp.yml
+++ b/config/grumphp.yml
@@ -12,6 +12,7 @@ grumphp:
     php_stan: ~
     yaml_lint: ~
     json_lint: ~
+    psalm: ~
   extensions:
     - Wunderio\GrumPHP\Task\PhpCompatibility\PhpCompatibilityExtensionLoader
     - Wunderio\GrumPHP\Task\PhpCheckSyntax\PhpCheckSyntaxExtensionLoader
@@ -21,3 +22,4 @@ grumphp:
     - Wunderio\GrumPHP\Task\PhpStan\PhpStanExtensionLoader
     - Wunderio\GrumPHP\Task\YamlLint\YamlLintExtensionLoader
     - Wunderio\GrumPHP\Task\JsonLint\JsonLintExtensionLoader
+    - Wunderio\GrumPHP\Task\Psalm\PsalmExtensionLoader

--- a/config/psalm.xml
+++ b/config/psalm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    errorLevel="6"
+    errorLevel="4"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"

--- a/config/psalm.xml
+++ b/config/psalm.xml
@@ -7,6 +7,10 @@
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
     autoloader="vendor/wunderio/code-quality/drupal-autoloader.php"
 >
+    <issueHandlers>
+      <UndefinedInterfaceMethod errorLevel="suppress" />
+      <ImplicitToStringCast errorLevel="suppress" />
+    </issueHandlers>
 
     <fileExtensions>
       <extension name=".php" />

--- a/config/psalm.xml
+++ b/config/psalm.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="6"
+    resolveFromConfigFile="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+
+    <fileExtensions>
+      <extension name=".php" />
+      <extension name=".inc" />
+      <extension name=".module" />
+      <extension name=".install" />
+      <extension name=".theme" />
+    </fileExtensions>
+</psalm>

--- a/config/psalm.xml
+++ b/config/psalm.xml
@@ -5,6 +5,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    autoloader="vendor/wunderio/code-quality/drupal-autoloader.php"
 >
 
     <fileExtensions>

--- a/config/psalm.xml
+++ b/config/psalm.xml
@@ -7,6 +7,14 @@
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
     autoloader="vendor/wunderio/code-quality/drupal-autoloader.php"
 >
+    <projectFiles>
+      <ignoreFiles>
+        <directory name="web/modules/contrib" />
+        <directory name="web/themes/contrib" />
+        <directory name="web/core" />
+      </ignoreFiles>
+    </projectFiles>
+
     <issueHandlers>
       <UndefinedInterfaceMethod errorLevel="suppress" />
       <ImplicitToStringCast errorLevel="suppress" />

--- a/drupal-autoloader.php
+++ b/drupal-autoloader.php
@@ -2,5 +2,8 @@
 
 use Wunderio\GrumPHP\Drupal\DrupalAutoloader;
 
+$vendor_dir = dirname(dirname(dirname(__FILE__)));
+$base_dir = dirname($vendor_dir);
+
 $o = new DrupalAutoloader();
-$o->register('/app');
+$o->register($base_dir);

--- a/drupal-autoloader.php
+++ b/drupal-autoloader.php
@@ -1,0 +1,6 @@
+<?php
+
+use Wunderio\GrumPHP\Drupal\DrupalAutoloader;
+
+$o = new DrupalAutoloader();
+$o->register('/app');

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -15,6 +15,7 @@ grumphp:
     json_lint: ~
     phpunit: ~
     php_check_syntax: ~
+    psalm: ~
   extensions:
     - Wunderio\GrumPHP\Task\PhpCompatibility\PhpCompatibilityExtensionLoader
     - Wunderio\GrumPHP\Task\PhpCheckSyntax\PhpCheckSyntaxExtensionLoader
@@ -24,3 +25,4 @@ grumphp:
     - Wunderio\GrumPHP\Task\PhpStan\PhpStanExtensionLoader
     - Wunderio\GrumPHP\Task\YamlLint\YamlLintExtensionLoader
     - Wunderio\GrumPHP\Task\JsonLint\JsonLintExtensionLoader
+    - Wunderio\GrumPHP\Task\Psalm\PsalmExtensionLoader

--- a/rulesets/WunderDrupal/Sniffs/Commenting/WunderInlineCommentSniff.php
+++ b/rulesets/WunderDrupal/Sniffs/Commenting/WunderInlineCommentSniff.php
@@ -96,7 +96,8 @@ class WunderInlineCommentSniff extends InlineCommentSniff implements Sniff {
         // The only exception to inline doc blocks is the /** @var */
         // declaration. Allow that in any form.
         $varTag = $phpcsFile->findNext([T_DOC_COMMENT_TAG], ($stackPtr + 1), $tokens[$stackPtr]['comment_closer'], FALSE, '@var');
-        if ($varTag === FALSE) {
+        $psalmSuppressTag = $phpcsFile->findNext([T_DOC_COMMENT_TAG], ($stackPtr + 1), $tokens[$stackPtr]['comment_closer'], FALSE, '@psalm-suppress');
+        if ($varTag === FALSE && $psalmSuppressTag === FALSE) {
           $error = 'Inline doc block comments are not allowed; use "/* Comment */" or "// Comment" instead';
           $phpcsFile->addError($error, $stackPtr, 'DocBlock');
         }

--- a/rulesets/WunderDrupal/Sniffs/Commenting/WunderInlineCommentSniff.php
+++ b/rulesets/WunderDrupal/Sniffs/Commenting/WunderInlineCommentSniff.php
@@ -12,411 +12,418 @@ use PHP_CodeSniffer\Util\Tokens;
  *
  * Add support for Psalm docblocks.
  */
-class WunderInlineCommentSniff extends InlineCommentSniff implements Sniff
-{
+class WunderInlineCommentSniff extends InlineCommentSniff implements Sniff {
 
-    /**
-     * Processes this test, when one of its tokens is encountered.
-     *
-     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-     * @param int                         $stackPtr  The position of the current token in the
-     *                                               stack passed in $tokens.
-     *
-     * @return int|void
-     */
-    public function process(File $phpcsFile, $stackPtr)
-    {
-        $tokens = $phpcsFile->getTokens();
+  /**
+   * {@inheritdoc}
+   */
+  public function process(File $phpcsFile, $stackPtr) {
+    $tokens = $phpcsFile->getTokens();
 
-        // If this is a function/class/interface doc block comment, skip it.
-        // We are only interested in inline doc block comments, which are
-        // not allowed.
-        if ($tokens[$stackPtr]['code'] === T_DOC_COMMENT_OPEN_TAG) {
-            $nextToken = $phpcsFile->findNext(
-                Tokens::$emptyTokens,
-                ($stackPtr + 1),
-                null,
-                true
-            );
+    // If this is a function/class/interface doc block comment, skip it.
+    // We are only interested in inline doc block comments, which are
+    // not allowed.
+    if ($tokens[$stackPtr]['code'] === T_DOC_COMMENT_OPEN_TAG) {
+      $nextToken = $phpcsFile->findNext(
+        Tokens::$emptyTokens,
+        ($stackPtr + 1),
+        NULL,
+        TRUE
+      );
 
-            $ignore = [
-                T_CLASS,
-                T_INTERFACE,
-                T_TRAIT,
-                T_FUNCTION,
-                T_CLOSURE,
-                T_PUBLIC,
-                T_PRIVATE,
-                T_PROTECTED,
-                T_FINAL,
-                T_STATIC,
-                T_ABSTRACT,
-                T_CONST,
-                T_PROPERTY,
-                T_INCLUDE,
-                T_INCLUDE_ONCE,
-                T_REQUIRE,
-                T_REQUIRE_ONCE,
-                T_VAR,
+      $ignore = [
+        T_CLASS,
+        T_INTERFACE,
+        T_TRAIT,
+        T_FUNCTION,
+        T_CLOSURE,
+        T_PUBLIC,
+        T_PRIVATE,
+        T_PROTECTED,
+        T_FINAL,
+        T_STATIC,
+        T_ABSTRACT,
+        T_CONST,
+        T_PROPERTY,
+        T_INCLUDE,
+        T_INCLUDE_ONCE,
+        T_REQUIRE,
+        T_REQUIRE_ONCE,
+        T_VAR,
+      ];
+
+      // Also ignore all doc blocks defined in the outer scope (no scope
+      // conditions are set).
+      if (in_array($tokens[$nextToken]['code'], $ignore, TRUE) === TRUE
+        || empty($tokens[$stackPtr]['conditions']) === TRUE
+      ) {
+        // phpcs:ignore Drupal.Commenting.FunctionComment.InvalidReturnNotVoid
+        return;
+      }
+
+      if ($phpcsFile->tokenizerType === 'JS') {
+        // We allow block comments if a function or object
+        // is being assigned to a variable.
+        $ignore    = Tokens::$emptyTokens;
+        $ignore[]  = T_EQUAL;
+        $ignore[]  = T_STRING;
+        $ignore[]  = T_OBJECT_OPERATOR;
+        $nextToken = $phpcsFile->findNext($ignore, ($nextToken + 1), NULL, TRUE);
+        if ($tokens[$nextToken]['code'] === T_FUNCTION
+          || $tokens[$nextToken]['code'] === T_CLOSURE
+          || $tokens[$nextToken]['code'] === T_OBJECT
+          || $tokens[$nextToken]['code'] === T_PROTOTYPE
+        ) {
+          // phpcs:ignore Drupal.Commenting.FunctionComment.InvalidReturnNotVoid
+          return;
+        }
+      }
+
+      $prevToken = $phpcsFile->findPrevious(
+        Tokens::$emptyTokens,
+        ($stackPtr - 1),
+        NULL,
+        TRUE
+      );
+
+      if ($tokens[$prevToken]['code'] === T_OPEN_TAG) {
+        // phpcs:ignore Drupal.Commenting.FunctionComment.InvalidReturnNotVoid
+        return;
+      }
+
+      // Inline doc blocks are allowed in JSDoc.
+      if ($tokens[$stackPtr]['content'] === '/**' && $phpcsFile->tokenizerType !== 'JS') {
+        // The only exception to inline doc blocks is the /** @var */
+        // declaration. Allow that in any form.
+        $varTag = $phpcsFile->findNext([T_DOC_COMMENT_TAG], ($stackPtr + 1), $tokens[$stackPtr]['comment_closer'], FALSE, '@var');
+        if ($varTag === FALSE) {
+          $error = 'Inline doc block comments are not allowed; use "/* Comment */" or "// Comment" instead';
+          $phpcsFile->addError($error, $stackPtr, 'DocBlock');
+        }
+      }
+    }
+
+    if ($tokens[$stackPtr]['content'][0] === '#') {
+      $error = 'Perl-style comments are not allowed; use "// Comment" instead';
+      $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'WrongStyle');
+      if ($fix === TRUE) {
+        $comment = ltrim($tokens[$stackPtr]['content'], "# \t");
+        $phpcsFile->fixer->replaceToken($stackPtr, "// $comment");
+      }
+    }
+
+    // We don't want end of block comments. Check if the last token before the
+    // comment is a closing curly brace.
+    $previousContent = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), NULL, TRUE);
+    if ($tokens[$previousContent]['line'] === $tokens[$stackPtr]['line']) {
+      if ($tokens[$previousContent]['code'] === T_CLOSE_CURLY_BRACKET) {
+        // phpcs:ignore Drupal.Commenting.FunctionComment.InvalidReturnNotVoid
+        return;
+      }
+
+      // Special case for JS files.
+      if ($tokens[$previousContent]['code'] === T_COMMA
+        || $tokens[$previousContent]['code'] === T_SEMICOLON
+      ) {
+        $lastContent = $phpcsFile->findPrevious(T_WHITESPACE, ($previousContent - 1), NULL, TRUE);
+        if ($tokens[$lastContent]['code'] === T_CLOSE_CURLY_BRACKET) {
+          // phpcs:ignore Drupal.Commenting.FunctionComment.InvalidReturnNotVoid
+          return;
+        }
+      }
+    }
+
+    // Only want inline comments.
+    if (substr($tokens[$stackPtr]['content'], 0, 2) !== '//') {
+      // phpcs:ignore Drupal.Commenting.FunctionComment.InvalidReturnNotVoid
+      return;
+    }
+
+    // Ignore code example lines.
+    if ($this->isInCodeExample($phpcsFile, $stackPtr) === TRUE) {
+      // phpcs:ignore Drupal.Commenting.FunctionComment.InvalidReturnNotVoid
+      return;
+    }
+
+    $commentTokens = [$stackPtr];
+
+    $nextComment = $stackPtr;
+    $lastComment = $stackPtr;
+    while (($nextComment = $phpcsFile->findNext(T_COMMENT, ($nextComment + 1), NULL, FALSE)) !== FALSE) {
+      if ($tokens[$nextComment]['line'] !== ($tokens[$lastComment]['line'] + 1)) {
+        break;
+      }
+
+      // Only want inline comments.
+      if (substr($tokens[$nextComment]['content'], 0, 2) !== '//') {
+        break;
+      }
+
+      // There is a comment on the very next line. If there is
+      // no code between the comments, they are part of the same
+      // comment block.
+      $prevNonWhitespace = $phpcsFile->findPrevious(T_WHITESPACE, ($nextComment - 1), $lastComment, TRUE);
+      if ($prevNonWhitespace !== $lastComment) {
+        break;
+      }
+
+      // A comment starting with "@" means a new comment section.
+      if (preg_match('|^//[\s]*@|', $tokens[$nextComment]['content']) === 1) {
+        break;
+      }
+
+      $commentTokens[] = $nextComment;
+      $lastComment     = $nextComment;
+    }
+
+    $commentText      = '';
+    $lastCommentToken = $stackPtr;
+    foreach ($commentTokens as $lastCommentToken) {
+      $comment = rtrim($tokens[$lastCommentToken]['content']);
+
+      if (trim(substr($comment, 2)) === '') {
+        continue;
+      }
+
+      $spaceCount = 0;
+      $tabFound   = FALSE;
+
+      $commentLength = strlen($comment);
+      for ($i = 2; $i < $commentLength; $i++) {
+        if ($comment[$i] === "\t") {
+          $tabFound = TRUE;
+          break;
+        }
+
+        if ($comment[$i] !== ' ') {
+          break;
+        }
+
+        $spaceCount++;
+      }
+
+      $fix = FALSE;
+      if ($tabFound === TRUE) {
+        $error = 'Tab found before comment text; expected "// %s" but found "%s"';
+        $data  = [
+          ltrim(substr($comment, 2)),
+          $comment,
+        ];
+        $fix   = $phpcsFile->addFixableError($error, $lastCommentToken, 'TabBefore', $data);
+      }
+      elseif ($spaceCount === 0) {
+        $error = 'No space found before comment text; expected "// %s" but found "%s"';
+        $data  = [
+          substr($comment, 2),
+          $comment,
+        ];
+        $fix   = $phpcsFile->addFixableError($error, $lastCommentToken, 'NoSpaceBefore', $data);
+      }//end if
+
+      if ($fix === TRUE) {
+        $newComment = '// ' . ltrim($tokens[$lastCommentToken]['content'], "/\t ");
+        $phpcsFile->fixer->replaceToken($lastCommentToken, $newComment);
+      }
+
+      if ($spaceCount > 1) {
+        // Check if there is a comment on the previous line that justifies the
+        // indentation.
+        $prevComment = $phpcsFile->findPrevious([T_COMMENT], ($lastCommentToken - 1), NULL, FALSE);
+        if (($prevComment !== FALSE) && (($tokens[$prevComment]['line']) === ($tokens[$lastCommentToken]['line'] - 1))) {
+          $prevCommentText = rtrim($tokens[$prevComment]['content']);
+          $prevSpaceCount  = 0;
+          for ($i = 2; $i < strlen($prevCommentText); $i++) {
+            if ($prevCommentText[$i] !== ' ') {
+              break;
+            }
+
+            $prevSpaceCount++;
+          }
+
+          if ($spaceCount > $prevSpaceCount && $prevSpaceCount > 0) {
+            // A previous comment could be a list item or @todo.
+            $indentationStarters = [
+              '-',
+              '@todo',
             ];
-
-            // Also ignore all doc blocks defined in the outer scope (no scope
-            // conditions are set).
-            if (in_array($tokens[$nextToken]['code'], $ignore, true) === true
-                || empty($tokens[$stackPtr]['conditions']) === true
-            ) {
-                return;
-            }
-
-            if ($phpcsFile->tokenizerType === 'JS') {
-                // We allow block comments if a function or object
-                // is being assigned to a variable.
-                $ignore    = Tokens::$emptyTokens;
-                $ignore[]  = T_EQUAL;
-                $ignore[]  = T_STRING;
-                $ignore[]  = T_OBJECT_OPERATOR;
-                $nextToken = $phpcsFile->findNext($ignore, ($nextToken + 1), null, true);
-                if ($tokens[$nextToken]['code'] === T_FUNCTION
-                    || $tokens[$nextToken]['code'] === T_CLOSURE
-                    || $tokens[$nextToken]['code'] === T_OBJECT
-                    || $tokens[$nextToken]['code'] === T_PROTOTYPE
-                ) {
-                    return;
+            $words = preg_split('/\s+/', $prevCommentText);
+            $numberedList = (bool) preg_match('/^[0-9]+\./', $words[1]);
+            if (in_array($words[1], $indentationStarters) === TRUE) {
+              if ($spaceCount !== ($prevSpaceCount + 2)) {
+                $error = 'Comment indentation error after %s element, expected %s spaces';
+                $fix = $phpcsFile->addFixableError($error, $lastCommentToken, 'SpacingBefore', [
+                  $words[1],
+                  ($prevSpaceCount + 2),
+                ]);
+                if ($fix === TRUE) {
+                  $newComment = '//' . str_repeat(' ', ($prevSpaceCount + 2)) . ltrim($tokens[$lastCommentToken]['content'], "/\t ");
+                  $phpcsFile->fixer->replaceToken($lastCommentToken, $newComment);
                 }
+              }
             }
-
-            $prevToken = $phpcsFile->findPrevious(
-                Tokens::$emptyTokens,
-                ($stackPtr - 1),
-                null,
-                true
-            );
-
-            if ($tokens[$prevToken]['code'] === T_OPEN_TAG) {
-                return;
-            }
-
-            // Inline doc blocks are allowed in JSDoc.
-            if ($tokens[$stackPtr]['content'] === '/**' && $phpcsFile->tokenizerType !== 'JS') {
-                // The only exception to inline doc blocks is the /** @var */
-                // declaration. Allow that in any form.
-                $varTag = $phpcsFile->findNext([T_DOC_COMMENT_TAG], ($stackPtr + 1), $tokens[$stackPtr]['comment_closer'], false, '@var');
-                if ($varTag === false) {
-                    $error = 'Inline doc block comments are not allowed; use "/* Comment */" or "// Comment" instead';
-                    $phpcsFile->addError($error, $stackPtr, 'DocBlock');
+            elseif ($numberedList === TRUE) {
+              $expectedSpaceCount = ($prevSpaceCount + strlen($words[1]) + 1);
+              if ($spaceCount !== $expectedSpaceCount) {
+                $error = 'Comment indentation error, expected %s spaces';
+                $fix   = $phpcsFile->addFixableError($error, $lastCommentToken, 'SpacingBefore', [$expectedSpaceCount]);
+                if ($fix === TRUE) {
+                  $newComment = '//' . str_repeat(' ', $expectedSpaceCount) . ltrim($tokens[$lastCommentToken]['content'], "/\t ");
+                  $phpcsFile->fixer->replaceToken($lastCommentToken, $newComment);
                 }
+              }
             }
-        }//end if
+            else {
+              $error = 'Comment indentation error, expected only %s spaces';
+              $phpcsFile->addError($error, $lastCommentToken, 'SpacingBefore', [$prevSpaceCount]);
+            }
+          }
+        }
+        else {
+          $error = '%s spaces found before inline comment; expected "// %s" but found "%s"';
+          $data  = [
+            $spaceCount,
+            substr($comment, (2 + $spaceCount)),
+            $comment,
+          ];
+          $fix   = $phpcsFile->addFixableError($error, $lastCommentToken, 'SpacingBefore', $data);
+          if ($fix === TRUE) {
+            $phpcsFile->fixer->replaceToken($lastCommentToken, '// ' . substr($comment, (2 + $spaceCount)) . $phpcsFile->eolChar);
+          }
+        }
+      }
 
-        if ($tokens[$stackPtr]['content'][0] === '#') {
-            $error = 'Perl-style comments are not allowed; use "// Comment" instead';
-            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'WrongStyle');
-            if ($fix === true) {
-                $comment = ltrim($tokens[$stackPtr]['content'], "# \t");
-                $phpcsFile->fixer->replaceToken($stackPtr, "// $comment");
-            }
+      $commentText .= trim(substr($tokens[$lastCommentToken]['content'], 2));
+    }
+
+    if ($commentText === '') {
+      $error = 'Blank comments are not allowed';
+      $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'Empty');
+      if ($fix === TRUE) {
+        $phpcsFile->fixer->replaceToken($stackPtr, '');
+      }
+
+      return ($lastCommentToken + 1);
+    }
+
+    $words = preg_split('/\s+/', $commentText);
+    if (preg_match('/^\p{Ll}/u', $commentText) === 1) {
+      // Allow special lower cased words that contain non-alpha characters
+      // (function references, machine names with underscores etc.).
+      $matches = [];
+      preg_match('/[a-z]+/', $words[0], $matches);
+      if (isset($matches[0]) === TRUE && $matches[0] === $words[0]) {
+        $error = 'Inline comments must start with a capital letter';
+        $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'NotCapital');
+        if ($fix === TRUE) {
+          // phpcs:ignore PHPCS_SecurityAudit.BadFunctions.PregReplace.PregReplaceDyn
+          $newComment = preg_replace("/$words[0]/", ucfirst($words[0]), $tokens[$stackPtr]['content'], 1);
+          $phpcsFile->fixer->replaceToken($stackPtr, $newComment);
+        }
+      }
+    }
+
+    // Only check the end of comment character if the start of the comment
+    // is a letter, indicating that the comment is just standard text.
+    if (preg_match('/^\p{L}/u', $commentText) === 1) {
+      $commentCloser   = $commentText[(strlen($commentText) - 1)];
+      $acceptedClosers = [
+        'full-stops'       => '.',
+        'exclamation marks'    => '!',
+        'question marks'     => '?',
+        'colons'         => ':',
+        'or closing parentheses' => ')',
+      ];
+
+      // Allow special last words like URLs or function references
+      // without punctuation.
+      $lastWord = $words[(count($words) - 1)];
+      $matches  = [];
+      preg_match('/https?:\/\/.+/', $lastWord, $matches);
+      $isUrl = isset($matches[0]) === TRUE;
+      preg_match('/[$a-zA-Z_]+\([$a-zA-Z_]*\)/', $lastWord, $matches);
+      $isFunction = isset($matches[0]) === TRUE;
+
+      // Also allow closing tags like @endlink or @endcode.
+      $isEndTag = $lastWord[0] === '@';
+
+      if (in_array($commentCloser, $acceptedClosers, TRUE) === FALSE
+        && $isUrl === FALSE && $isFunction === FALSE && $isEndTag === FALSE
+      ) {
+        $error = 'Inline comments must end in %s';
+        $ender = '';
+        foreach ($acceptedClosers as $closerName => $symbol) {
+          $ender .= ' ' . $closerName . ',';
         }
 
-        // We don't want end of block comments. Check if the last token before the
-        // comment is a closing curly brace.
-        $previousContent = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
-        if ($tokens[$previousContent]['line'] === $tokens[$stackPtr]['line']) {
-            if ($tokens[$previousContent]['code'] === T_CLOSE_CURLY_BRACKET) {
-                return;
-            }
-
-            // Special case for JS files.
-            if ($tokens[$previousContent]['code'] === T_COMMA
-                || $tokens[$previousContent]['code'] === T_SEMICOLON
-            ) {
-                $lastContent = $phpcsFile->findPrevious(T_WHITESPACE, ($previousContent - 1), null, true);
-                if ($tokens[$lastContent]['code'] === T_CLOSE_CURLY_BRACKET) {
-                    return;
-                }
-            }
+        $ender = trim($ender, ' ,');
+        $data  = [$ender];
+        $fix   = $phpcsFile->addFixableError($error, $lastCommentToken, 'InvalidEndChar', $data);
+        if ($fix === TRUE) {
+          $newContent = preg_replace('/(\s+)$/', '.$1', $tokens[$lastCommentToken]['content']);
+          $phpcsFile->fixer->replaceToken($lastCommentToken, $newContent);
         }
+      }
+    }
 
-        // Only want inline comments.
-        if (substr($tokens[$stackPtr]['content'], 0, 2) !== '//') {
-            return;
-        }
-
-        // Ignore code example lines.
-        if ($this->isInCodeExample($phpcsFile, $stackPtr) === true) {
-            return;
-        }
-
-        $commentTokens = [$stackPtr];
-
-        $nextComment = $stackPtr;
-        $lastComment = $stackPtr;
-        while (($nextComment = $phpcsFile->findNext(T_COMMENT, ($nextComment + 1), null, false)) !== false) {
-            if ($tokens[$nextComment]['line'] !== ($tokens[$lastComment]['line'] + 1)) {
-                break;
-            }
-
-            // Only want inline comments.
-            if (substr($tokens[$nextComment]['content'], 0, 2) !== '//') {
-                break;
-            }
-
-            // There is a comment on the very next line. If there is
-            // no code between the comments, they are part of the same
-            // comment block.
-            $prevNonWhitespace = $phpcsFile->findPrevious(T_WHITESPACE, ($nextComment - 1), $lastComment, true);
-            if ($prevNonWhitespace !== $lastComment) {
-                break;
-            }
-
-            // A comment starting with "@" means a new comment section.
-            if (preg_match('|^//[\s]*@|', $tokens[$nextComment]['content']) === 1) {
-                break;
-            }
-
-            $commentTokens[] = $nextComment;
-            $lastComment     = $nextComment;
-        }//end while
-
-        $commentText      = '';
-        $lastCommentToken = $stackPtr;
-        foreach ($commentTokens as $lastCommentToken) {
-            $comment = rtrim($tokens[$lastCommentToken]['content']);
-
-            if (trim(substr($comment, 2)) === '') {
-                continue;
-            }
-
-            $spaceCount = 0;
-            $tabFound   = false;
-
-            $commentLength = strlen($comment);
-            for ($i = 2; $i < $commentLength; $i++) {
-                if ($comment[$i] === "\t") {
-                    $tabFound = true;
-                    break;
-                }
-
-                if ($comment[$i] !== ' ') {
-                    break;
-                }
-
-                $spaceCount++;
-            }
-
-            $fix = false;
-            if ($tabFound === true) {
-                $error = 'Tab found before comment text; expected "// %s" but found "%s"';
-                $data  = [
-                    ltrim(substr($comment, 2)),
-                    $comment,
-                ];
-                $fix   = $phpcsFile->addFixableError($error, $lastCommentToken, 'TabBefore', $data);
-            } else if ($spaceCount === 0) {
-                $error = 'No space found before comment text; expected "// %s" but found "%s"';
-                $data  = [
-                    substr($comment, 2),
-                    $comment,
-                ];
-                $fix   = $phpcsFile->addFixableError($error, $lastCommentToken, 'NoSpaceBefore', $data);
-            }//end if
-
-            if ($fix === true) {
-                $newComment = '// '.ltrim($tokens[$lastCommentToken]['content'], "/\t ");
-                $phpcsFile->fixer->replaceToken($lastCommentToken, $newComment);
-            }
-
-            if ($spaceCount > 1) {
-                // Check if there is a comment on the previous line that justifies the
-                // indentation.
-                $prevComment = $phpcsFile->findPrevious([T_COMMENT], ($lastCommentToken - 1), null, false);
-                if (($prevComment !== false) && (($tokens[$prevComment]['line']) === ($tokens[$lastCommentToken]['line'] - 1))) {
-                    $prevCommentText = rtrim($tokens[$prevComment]['content']);
-                    $prevSpaceCount  = 0;
-                    for ($i = 2; $i < strlen($prevCommentText); $i++) {
-                        if ($prevCommentText[$i] !== ' ') {
-                            break;
-                        }
-
-                        $prevSpaceCount++;
-                    }
-
-                    if ($spaceCount > $prevSpaceCount && $prevSpaceCount > 0) {
-                        // A previous comment could be a list item or @todo.
-                        $indentationStarters = [
-                            '-',
-                            '@todo',
-                        ];
-                        $words        = preg_split('/\s+/', $prevCommentText);
-                        $numberedList = (bool) preg_match('/^[0-9]+\./', $words[1]);
-                        if (in_array($words[1], $indentationStarters) === true) {
-                            if ($spaceCount !== ($prevSpaceCount + 2)) {
-                                $error = 'Comment indentation error after %s element, expected %s spaces';
-                                $fix   = $phpcsFile->addFixableError($error, $lastCommentToken, 'SpacingBefore', [$words[1], ($prevSpaceCount + 2)]);
-                                if ($fix === true) {
-                                    $newComment = '//'.str_repeat(' ', ($prevSpaceCount + 2)).ltrim($tokens[$lastCommentToken]['content'], "/\t ");
-                                    $phpcsFile->fixer->replaceToken($lastCommentToken, $newComment);
-                                }
-                            }
-                        } else if ($numberedList === true) {
-                            $expectedSpaceCount = ($prevSpaceCount + strlen($words[1]) + 1);
-                            if ($spaceCount !== $expectedSpaceCount) {
-                                $error = 'Comment indentation error, expected %s spaces';
-                                $fix   = $phpcsFile->addFixableError($error, $lastCommentToken, 'SpacingBefore', [$expectedSpaceCount]);
-                                if ($fix === true) {
-                                    $newComment = '//'.str_repeat(' ', $expectedSpaceCount).ltrim($tokens[$lastCommentToken]['content'], "/\t ");
-                                    $phpcsFile->fixer->replaceToken($lastCommentToken, $newComment);
-                                }
-                            }
-                        } else {
-                            $error = 'Comment indentation error, expected only %s spaces';
-                            $phpcsFile->addError($error, $lastCommentToken, 'SpacingBefore', [$prevSpaceCount]);
-                        }//end if
-                    }//end if
-                } else {
-                    $error = '%s spaces found before inline comment; expected "// %s" but found "%s"';
-                    $data  = [
-                        $spaceCount,
-                        substr($comment, (2 + $spaceCount)),
-                        $comment,
-                    ];
-                    $fix   = $phpcsFile->addFixableError($error, $lastCommentToken, 'SpacingBefore', $data);
-                    if ($fix === true) {
-                        $phpcsFile->fixer->replaceToken($lastCommentToken, '// '.substr($comment, (2 + $spaceCount)).$phpcsFile->eolChar);
-                    }
-                }//end if
-            }//end if
-
-            $commentText .= trim(substr($tokens[$lastCommentToken]['content'], 2));
-        }//end foreach
-
-        if ($commentText === '') {
-            $error = 'Blank comments are not allowed';
-            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'Empty');
-            if ($fix === true) {
-                $phpcsFile->fixer->replaceToken($stackPtr, '');
-            }
-
-            return ($lastCommentToken + 1);
-        }
-
-        $words = preg_split('/\s+/', $commentText);
-        if (preg_match('/^\p{Ll}/u', $commentText) === 1) {
-            // Allow special lower cased words that contain non-alpha characters
-            // (function references, machine names with underscores etc.).
-            $matches = [];
-            preg_match('/[a-z]+/', $words[0], $matches);
-            if (isset($matches[0]) === true && $matches[0] === $words[0]) {
-                $error = 'Inline comments must start with a capital letter';
-                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'NotCapital');
-                if ($fix === true) {
-                    $newComment = preg_replace("/$words[0]/", ucfirst($words[0]), $tokens[$stackPtr]['content'], 1);
-                    $phpcsFile->fixer->replaceToken($stackPtr, $newComment);
-                }
-            }
-        }
-
-        // Only check the end of comment character if the start of the comment
-        // is a letter, indicating that the comment is just standard text.
-        if (preg_match('/^\p{L}/u', $commentText) === 1) {
-            $commentCloser   = $commentText[(strlen($commentText) - 1)];
-            $acceptedClosers = [
-                'full-stops'             => '.',
-                'exclamation marks'      => '!',
-                'question marks'         => '?',
-                'colons'                 => ':',
-                'or closing parentheses' => ')',
-            ];
-
-            // Allow special last words like URLs or function references
-            // without punctuation.
-            $lastWord = $words[(count($words) - 1)];
-            $matches  = [];
-            preg_match('/https?:\/\/.+/', $lastWord, $matches);
-            $isUrl = isset($matches[0]) === true;
-            preg_match('/[$a-zA-Z_]+\([$a-zA-Z_]*\)/', $lastWord, $matches);
-            $isFunction = isset($matches[0]) === true;
-
-            // Also allow closing tags like @endlink or @endcode.
-            $isEndTag = $lastWord[0] === '@';
-
-            if (in_array($commentCloser, $acceptedClosers, true) === false
-                && $isUrl === false && $isFunction === false && $isEndTag === false
-            ) {
-                $error = 'Inline comments must end in %s';
-                $ender = '';
-                foreach ($acceptedClosers as $closerName => $symbol) {
-                    $ender .= ' '.$closerName.',';
-                }
-
-                $ender = trim($ender, ' ,');
-                $data  = [$ender];
-                $fix   = $phpcsFile->addFixableError($error, $lastCommentToken, 'InvalidEndChar', $data);
-                if ($fix === true) {
-                    $newContent = preg_replace('/(\s+)$/', '.$1', $tokens[$lastCommentToken]['content']);
-                    $phpcsFile->fixer->replaceToken($lastCommentToken, $newContent);
-                }
-            }
-        }//end if
-
-        // Finally, the line below the last comment cannot be empty if this inline
-        // comment is on a line by itself.
-        if ($tokens[$previousContent]['line'] < $tokens[$stackPtr]['line']) {
-            $next = $phpcsFile->findNext(T_WHITESPACE, ($lastCommentToken + 1), null, true);
-            if ($next === false) {
-                // Ignore if the comment is the last non-whitespace token in a file.
-                return ($lastCommentToken + 1);
-            }
-
-            if ($tokens[$next]['code'] === T_DOC_COMMENT_OPEN_TAG) {
-                // If this inline comment is followed by a docblock,
-                // ignore spacing as docblock/function etc spacing rules
-                // are likely to conflict with our rules.
-                return ($lastCommentToken + 1);
-            }
-
-            $errorCode = 'SpacingAfter';
-
-            if (isset($tokens[$stackPtr]['conditions']) === true) {
-                $conditions   = $tokens[$stackPtr]['conditions'];
-                $type         = end($conditions);
-                $conditionPtr = key($conditions);
-
-                if (($type === T_FUNCTION || $type === T_CLOSURE)
-                    && $tokens[$conditionPtr]['scope_closer'] === $next
-                ) {
-                    $errorCode = 'SpacingAfterAtFunctionEnd';
-                }
-            }
-
-            for ($i = ($lastCommentToken + 1); $i < $phpcsFile->numTokens; $i++) {
-                if ($tokens[$i]['line'] === ($tokens[$lastCommentToken]['line'] + 1)) {
-                    if ($tokens[$i]['code'] !== T_WHITESPACE) {
-                        return ($lastCommentToken + 1);
-                    }
-                } else if ($tokens[$i]['line'] > ($tokens[$lastCommentToken]['line'] + 1)) {
-                    break;
-                }
-            }
-
-            $error = 'There must be no blank line following an inline comment';
-            $fix   = $phpcsFile->addFixableWarning($error, $lastCommentToken, $errorCode);
-            if ($fix === true) {
-                $phpcsFile->fixer->beginChangeset();
-                for ($i = ($lastCommentToken + 1); $i < $next; $i++) {
-                    if ($tokens[$i]['line'] === $tokens[$next]['line']) {
-                        break;
-                    }
-
-                    $phpcsFile->fixer->replaceToken($i, '');
-                }
-
-                $phpcsFile->fixer->endChangeset();
-            }
-        }//end if
-
+    // Finally, the line below the last comment cannot be empty if this inline
+    // comment is on a line by itself.
+    if ($tokens[$previousContent]['line'] < $tokens[$stackPtr]['line']) {
+      $next = $phpcsFile->findNext(T_WHITESPACE, ($lastCommentToken + 1), NULL, TRUE);
+      if ($next === FALSE) {
+        // Ignore if the comment is the last non-whitespace token in a file.
         return ($lastCommentToken + 1);
+      }
 
-    }//end process()
+      if ($tokens[$next]['code'] === T_DOC_COMMENT_OPEN_TAG) {
+        // If this inline comment is followed by a docblock,
+        // ignore spacing as docblock/function etc spacing rules
+        // are likely to conflict with our rules.
+        return ($lastCommentToken + 1);
+      }
 
+      $errorCode = 'SpacingAfter';
 
-}//end class
+      if (isset($tokens[$stackPtr]['conditions']) === TRUE) {
+        $conditions = $tokens[$stackPtr]['conditions'];
+        $type = end($conditions);
+        $conditionPtr = key($conditions);
+
+        if (($type === T_FUNCTION || $type === T_CLOSURE)
+          && $tokens[$conditionPtr]['scope_closer'] === $next
+        ) {
+          $errorCode = 'SpacingAfterAtFunctionEnd';
+        }
+      }
+
+      for ($i = ($lastCommentToken + 1); $i < $phpcsFile->numTokens; $i++) {
+        if ($tokens[$i]['line'] === ($tokens[$lastCommentToken]['line'] + 1)) {
+          if ($tokens[$i]['code'] !== T_WHITESPACE) {
+            return ($lastCommentToken + 1);
+          }
+        }
+        elseif ($tokens[$i]['line'] > ($tokens[$lastCommentToken]['line'] + 1)) {
+          break;
+        }
+      }
+
+      $error = 'There must be no blank line following an inline comment';
+      $fix   = $phpcsFile->addFixableWarning($error, $lastCommentToken, $errorCode);
+      if ($fix === TRUE) {
+        $phpcsFile->fixer->beginChangeset();
+        for ($i = ($lastCommentToken + 1); $i < $next; $i++) {
+          if ($tokens[$i]['line'] === $tokens[$next]['line']) {
+            break;
+          }
+
+          $phpcsFile->fixer->replaceToken($i, '');
+        }
+
+        $phpcsFile->fixer->endChangeset();
+      }
+    }
+
+    return ($lastCommentToken + 1);
+
+  }
+
+}

--- a/rulesets/WunderDrupal/Sniffs/Commenting/WunderInlineCommentSniff.php
+++ b/rulesets/WunderDrupal/Sniffs/Commenting/WunderInlineCommentSniff.php
@@ -1,0 +1,422 @@
+<?php
+
+namespace Wunderio\GrumPHP\PhpCodingStandards\Sniffs\Commenting;
+
+use Drupal\Sniffs\Commenting\InlineCommentSniff;
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Util\Tokens;
+
+/**
+ * Customized Drupal\Sniffs\Commenting\InlineCommentSniff.
+ *
+ * Add support for Psalm docblocks.
+ */
+class WunderInlineCommentSniff extends InlineCommentSniff implements Sniff
+{
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+     * @param int                         $stackPtr  The position of the current token in the
+     *                                               stack passed in $tokens.
+     *
+     * @return int|void
+     */
+    public function process(File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // If this is a function/class/interface doc block comment, skip it.
+        // We are only interested in inline doc block comments, which are
+        // not allowed.
+        if ($tokens[$stackPtr]['code'] === T_DOC_COMMENT_OPEN_TAG) {
+            $nextToken = $phpcsFile->findNext(
+                Tokens::$emptyTokens,
+                ($stackPtr + 1),
+                null,
+                true
+            );
+
+            $ignore = [
+                T_CLASS,
+                T_INTERFACE,
+                T_TRAIT,
+                T_FUNCTION,
+                T_CLOSURE,
+                T_PUBLIC,
+                T_PRIVATE,
+                T_PROTECTED,
+                T_FINAL,
+                T_STATIC,
+                T_ABSTRACT,
+                T_CONST,
+                T_PROPERTY,
+                T_INCLUDE,
+                T_INCLUDE_ONCE,
+                T_REQUIRE,
+                T_REQUIRE_ONCE,
+                T_VAR,
+            ];
+
+            // Also ignore all doc blocks defined in the outer scope (no scope
+            // conditions are set).
+            if (in_array($tokens[$nextToken]['code'], $ignore, true) === true
+                || empty($tokens[$stackPtr]['conditions']) === true
+            ) {
+                return;
+            }
+
+            if ($phpcsFile->tokenizerType === 'JS') {
+                // We allow block comments if a function or object
+                // is being assigned to a variable.
+                $ignore    = Tokens::$emptyTokens;
+                $ignore[]  = T_EQUAL;
+                $ignore[]  = T_STRING;
+                $ignore[]  = T_OBJECT_OPERATOR;
+                $nextToken = $phpcsFile->findNext($ignore, ($nextToken + 1), null, true);
+                if ($tokens[$nextToken]['code'] === T_FUNCTION
+                    || $tokens[$nextToken]['code'] === T_CLOSURE
+                    || $tokens[$nextToken]['code'] === T_OBJECT
+                    || $tokens[$nextToken]['code'] === T_PROTOTYPE
+                ) {
+                    return;
+                }
+            }
+
+            $prevToken = $phpcsFile->findPrevious(
+                Tokens::$emptyTokens,
+                ($stackPtr - 1),
+                null,
+                true
+            );
+
+            if ($tokens[$prevToken]['code'] === T_OPEN_TAG) {
+                return;
+            }
+
+            // Inline doc blocks are allowed in JSDoc.
+            if ($tokens[$stackPtr]['content'] === '/**' && $phpcsFile->tokenizerType !== 'JS') {
+                // The only exception to inline doc blocks is the /** @var */
+                // declaration. Allow that in any form.
+                $varTag = $phpcsFile->findNext([T_DOC_COMMENT_TAG], ($stackPtr + 1), $tokens[$stackPtr]['comment_closer'], false, '@var');
+                if ($varTag === false) {
+                    $error = 'Inline doc block comments are not allowed; use "/* Comment */" or "// Comment" instead';
+                    $phpcsFile->addError($error, $stackPtr, 'DocBlock');
+                }
+            }
+        }//end if
+
+        if ($tokens[$stackPtr]['content'][0] === '#') {
+            $error = 'Perl-style comments are not allowed; use "// Comment" instead';
+            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'WrongStyle');
+            if ($fix === true) {
+                $comment = ltrim($tokens[$stackPtr]['content'], "# \t");
+                $phpcsFile->fixer->replaceToken($stackPtr, "// $comment");
+            }
+        }
+
+        // We don't want end of block comments. Check if the last token before the
+        // comment is a closing curly brace.
+        $previousContent = $phpcsFile->findPrevious(T_WHITESPACE, ($stackPtr - 1), null, true);
+        if ($tokens[$previousContent]['line'] === $tokens[$stackPtr]['line']) {
+            if ($tokens[$previousContent]['code'] === T_CLOSE_CURLY_BRACKET) {
+                return;
+            }
+
+            // Special case for JS files.
+            if ($tokens[$previousContent]['code'] === T_COMMA
+                || $tokens[$previousContent]['code'] === T_SEMICOLON
+            ) {
+                $lastContent = $phpcsFile->findPrevious(T_WHITESPACE, ($previousContent - 1), null, true);
+                if ($tokens[$lastContent]['code'] === T_CLOSE_CURLY_BRACKET) {
+                    return;
+                }
+            }
+        }
+
+        // Only want inline comments.
+        if (substr($tokens[$stackPtr]['content'], 0, 2) !== '//') {
+            return;
+        }
+
+        // Ignore code example lines.
+        if ($this->isInCodeExample($phpcsFile, $stackPtr) === true) {
+            return;
+        }
+
+        $commentTokens = [$stackPtr];
+
+        $nextComment = $stackPtr;
+        $lastComment = $stackPtr;
+        while (($nextComment = $phpcsFile->findNext(T_COMMENT, ($nextComment + 1), null, false)) !== false) {
+            if ($tokens[$nextComment]['line'] !== ($tokens[$lastComment]['line'] + 1)) {
+                break;
+            }
+
+            // Only want inline comments.
+            if (substr($tokens[$nextComment]['content'], 0, 2) !== '//') {
+                break;
+            }
+
+            // There is a comment on the very next line. If there is
+            // no code between the comments, they are part of the same
+            // comment block.
+            $prevNonWhitespace = $phpcsFile->findPrevious(T_WHITESPACE, ($nextComment - 1), $lastComment, true);
+            if ($prevNonWhitespace !== $lastComment) {
+                break;
+            }
+
+            // A comment starting with "@" means a new comment section.
+            if (preg_match('|^//[\s]*@|', $tokens[$nextComment]['content']) === 1) {
+                break;
+            }
+
+            $commentTokens[] = $nextComment;
+            $lastComment     = $nextComment;
+        }//end while
+
+        $commentText      = '';
+        $lastCommentToken = $stackPtr;
+        foreach ($commentTokens as $lastCommentToken) {
+            $comment = rtrim($tokens[$lastCommentToken]['content']);
+
+            if (trim(substr($comment, 2)) === '') {
+                continue;
+            }
+
+            $spaceCount = 0;
+            $tabFound   = false;
+
+            $commentLength = strlen($comment);
+            for ($i = 2; $i < $commentLength; $i++) {
+                if ($comment[$i] === "\t") {
+                    $tabFound = true;
+                    break;
+                }
+
+                if ($comment[$i] !== ' ') {
+                    break;
+                }
+
+                $spaceCount++;
+            }
+
+            $fix = false;
+            if ($tabFound === true) {
+                $error = 'Tab found before comment text; expected "// %s" but found "%s"';
+                $data  = [
+                    ltrim(substr($comment, 2)),
+                    $comment,
+                ];
+                $fix   = $phpcsFile->addFixableError($error, $lastCommentToken, 'TabBefore', $data);
+            } else if ($spaceCount === 0) {
+                $error = 'No space found before comment text; expected "// %s" but found "%s"';
+                $data  = [
+                    substr($comment, 2),
+                    $comment,
+                ];
+                $fix   = $phpcsFile->addFixableError($error, $lastCommentToken, 'NoSpaceBefore', $data);
+            }//end if
+
+            if ($fix === true) {
+                $newComment = '// '.ltrim($tokens[$lastCommentToken]['content'], "/\t ");
+                $phpcsFile->fixer->replaceToken($lastCommentToken, $newComment);
+            }
+
+            if ($spaceCount > 1) {
+                // Check if there is a comment on the previous line that justifies the
+                // indentation.
+                $prevComment = $phpcsFile->findPrevious([T_COMMENT], ($lastCommentToken - 1), null, false);
+                if (($prevComment !== false) && (($tokens[$prevComment]['line']) === ($tokens[$lastCommentToken]['line'] - 1))) {
+                    $prevCommentText = rtrim($tokens[$prevComment]['content']);
+                    $prevSpaceCount  = 0;
+                    for ($i = 2; $i < strlen($prevCommentText); $i++) {
+                        if ($prevCommentText[$i] !== ' ') {
+                            break;
+                        }
+
+                        $prevSpaceCount++;
+                    }
+
+                    if ($spaceCount > $prevSpaceCount && $prevSpaceCount > 0) {
+                        // A previous comment could be a list item or @todo.
+                        $indentationStarters = [
+                            '-',
+                            '@todo',
+                        ];
+                        $words        = preg_split('/\s+/', $prevCommentText);
+                        $numberedList = (bool) preg_match('/^[0-9]+\./', $words[1]);
+                        if (in_array($words[1], $indentationStarters) === true) {
+                            if ($spaceCount !== ($prevSpaceCount + 2)) {
+                                $error = 'Comment indentation error after %s element, expected %s spaces';
+                                $fix   = $phpcsFile->addFixableError($error, $lastCommentToken, 'SpacingBefore', [$words[1], ($prevSpaceCount + 2)]);
+                                if ($fix === true) {
+                                    $newComment = '//'.str_repeat(' ', ($prevSpaceCount + 2)).ltrim($tokens[$lastCommentToken]['content'], "/\t ");
+                                    $phpcsFile->fixer->replaceToken($lastCommentToken, $newComment);
+                                }
+                            }
+                        } else if ($numberedList === true) {
+                            $expectedSpaceCount = ($prevSpaceCount + strlen($words[1]) + 1);
+                            if ($spaceCount !== $expectedSpaceCount) {
+                                $error = 'Comment indentation error, expected %s spaces';
+                                $fix   = $phpcsFile->addFixableError($error, $lastCommentToken, 'SpacingBefore', [$expectedSpaceCount]);
+                                if ($fix === true) {
+                                    $newComment = '//'.str_repeat(' ', $expectedSpaceCount).ltrim($tokens[$lastCommentToken]['content'], "/\t ");
+                                    $phpcsFile->fixer->replaceToken($lastCommentToken, $newComment);
+                                }
+                            }
+                        } else {
+                            $error = 'Comment indentation error, expected only %s spaces';
+                            $phpcsFile->addError($error, $lastCommentToken, 'SpacingBefore', [$prevSpaceCount]);
+                        }//end if
+                    }//end if
+                } else {
+                    $error = '%s spaces found before inline comment; expected "// %s" but found "%s"';
+                    $data  = [
+                        $spaceCount,
+                        substr($comment, (2 + $spaceCount)),
+                        $comment,
+                    ];
+                    $fix   = $phpcsFile->addFixableError($error, $lastCommentToken, 'SpacingBefore', $data);
+                    if ($fix === true) {
+                        $phpcsFile->fixer->replaceToken($lastCommentToken, '// '.substr($comment, (2 + $spaceCount)).$phpcsFile->eolChar);
+                    }
+                }//end if
+            }//end if
+
+            $commentText .= trim(substr($tokens[$lastCommentToken]['content'], 2));
+        }//end foreach
+
+        if ($commentText === '') {
+            $error = 'Blank comments are not allowed';
+            $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'Empty');
+            if ($fix === true) {
+                $phpcsFile->fixer->replaceToken($stackPtr, '');
+            }
+
+            return ($lastCommentToken + 1);
+        }
+
+        $words = preg_split('/\s+/', $commentText);
+        if (preg_match('/^\p{Ll}/u', $commentText) === 1) {
+            // Allow special lower cased words that contain non-alpha characters
+            // (function references, machine names with underscores etc.).
+            $matches = [];
+            preg_match('/[a-z]+/', $words[0], $matches);
+            if (isset($matches[0]) === true && $matches[0] === $words[0]) {
+                $error = 'Inline comments must start with a capital letter';
+                $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'NotCapital');
+                if ($fix === true) {
+                    $newComment = preg_replace("/$words[0]/", ucfirst($words[0]), $tokens[$stackPtr]['content'], 1);
+                    $phpcsFile->fixer->replaceToken($stackPtr, $newComment);
+                }
+            }
+        }
+
+        // Only check the end of comment character if the start of the comment
+        // is a letter, indicating that the comment is just standard text.
+        if (preg_match('/^\p{L}/u', $commentText) === 1) {
+            $commentCloser   = $commentText[(strlen($commentText) - 1)];
+            $acceptedClosers = [
+                'full-stops'             => '.',
+                'exclamation marks'      => '!',
+                'question marks'         => '?',
+                'colons'                 => ':',
+                'or closing parentheses' => ')',
+            ];
+
+            // Allow special last words like URLs or function references
+            // without punctuation.
+            $lastWord = $words[(count($words) - 1)];
+            $matches  = [];
+            preg_match('/https?:\/\/.+/', $lastWord, $matches);
+            $isUrl = isset($matches[0]) === true;
+            preg_match('/[$a-zA-Z_]+\([$a-zA-Z_]*\)/', $lastWord, $matches);
+            $isFunction = isset($matches[0]) === true;
+
+            // Also allow closing tags like @endlink or @endcode.
+            $isEndTag = $lastWord[0] === '@';
+
+            if (in_array($commentCloser, $acceptedClosers, true) === false
+                && $isUrl === false && $isFunction === false && $isEndTag === false
+            ) {
+                $error = 'Inline comments must end in %s';
+                $ender = '';
+                foreach ($acceptedClosers as $closerName => $symbol) {
+                    $ender .= ' '.$closerName.',';
+                }
+
+                $ender = trim($ender, ' ,');
+                $data  = [$ender];
+                $fix   = $phpcsFile->addFixableError($error, $lastCommentToken, 'InvalidEndChar', $data);
+                if ($fix === true) {
+                    $newContent = preg_replace('/(\s+)$/', '.$1', $tokens[$lastCommentToken]['content']);
+                    $phpcsFile->fixer->replaceToken($lastCommentToken, $newContent);
+                }
+            }
+        }//end if
+
+        // Finally, the line below the last comment cannot be empty if this inline
+        // comment is on a line by itself.
+        if ($tokens[$previousContent]['line'] < $tokens[$stackPtr]['line']) {
+            $next = $phpcsFile->findNext(T_WHITESPACE, ($lastCommentToken + 1), null, true);
+            if ($next === false) {
+                // Ignore if the comment is the last non-whitespace token in a file.
+                return ($lastCommentToken + 1);
+            }
+
+            if ($tokens[$next]['code'] === T_DOC_COMMENT_OPEN_TAG) {
+                // If this inline comment is followed by a docblock,
+                // ignore spacing as docblock/function etc spacing rules
+                // are likely to conflict with our rules.
+                return ($lastCommentToken + 1);
+            }
+
+            $errorCode = 'SpacingAfter';
+
+            if (isset($tokens[$stackPtr]['conditions']) === true) {
+                $conditions   = $tokens[$stackPtr]['conditions'];
+                $type         = end($conditions);
+                $conditionPtr = key($conditions);
+
+                if (($type === T_FUNCTION || $type === T_CLOSURE)
+                    && $tokens[$conditionPtr]['scope_closer'] === $next
+                ) {
+                    $errorCode = 'SpacingAfterAtFunctionEnd';
+                }
+            }
+
+            for ($i = ($lastCommentToken + 1); $i < $phpcsFile->numTokens; $i++) {
+                if ($tokens[$i]['line'] === ($tokens[$lastCommentToken]['line'] + 1)) {
+                    if ($tokens[$i]['code'] !== T_WHITESPACE) {
+                        return ($lastCommentToken + 1);
+                    }
+                } else if ($tokens[$i]['line'] > ($tokens[$lastCommentToken]['line'] + 1)) {
+                    break;
+                }
+            }
+
+            $error = 'There must be no blank line following an inline comment';
+            $fix   = $phpcsFile->addFixableWarning($error, $lastCommentToken, $errorCode);
+            if ($fix === true) {
+                $phpcsFile->fixer->beginChangeset();
+                for ($i = ($lastCommentToken + 1); $i < $next; $i++) {
+                    if ($tokens[$i]['line'] === $tokens[$next]['line']) {
+                        break;
+                    }
+
+                    $phpcsFile->fixer->replaceToken($i, '');
+                }
+
+                $phpcsFile->fixer->endChangeset();
+            }
+        }//end if
+
+        return ($lastCommentToken + 1);
+
+    }//end process()
+
+
+}//end class

--- a/rulesets/WunderDrupal/ruleset.xml
+++ b/rulesets/WunderDrupal/ruleset.xml
@@ -18,6 +18,7 @@
     <rule ref="Drupal">
         <exclude name="Drupal.Files.TxtFileLineLength" />
         <exclude name="Drupal.InfoFiles.AutoAddedKeys" />
+        <exclude name="Drupal.Commenting.InlineComment.DocBlock" />
     </rule>
 
     <!-- force short array notation - []  -->

--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -1,0 +1,301 @@
+<?php declare(strict_types=1);
+
+namespace Wunderio\GrumPHP\Drupal;
+
+use Drupal\Core\DependencyInjection\ContainerNotInitializedException;
+use DrupalFinder\DrupalFinder;
+use Nette\Utils\Finder;
+use PHPStan\DependencyInjection\Container;
+use PHPStan\Drupal\ExtensionDiscovery;
+use PHPStan\Drupal\ServiceMap;
+use Symfony\Component\Yaml\Yaml;
+use PHPStan\Drupal\Extension;
+
+class DrupalAutoloader {
+  /**
+   * @var \Composer\Autoload\ClassLoader
+   */
+  private $autoloader;
+
+  /**
+   * @var string
+   */
+  private $drupalRoot;
+
+  /**
+   * List of available modules.
+   *
+   * @var Extension[]
+   */
+  protected $moduleData = [];
+
+  /**
+   * List of available themes.
+   *
+   * @var Extension[]
+   */
+  protected $themeData = [];
+
+  /**
+   * @var array<array<string, string>>
+   */
+  private $serviceMap = [];
+
+  /**
+   * @var array<string, string>
+   */
+  private $serviceYamls = [];
+
+  /**
+   * @var array<string, string>
+   */
+  private $serviceClassProviders = [];
+
+  /**
+   * @var ?\Wunderio\GrumPHP\Drupal\ExtensionDiscovery
+   */
+  private $extensionDiscovery;
+
+  /**
+   * @var array
+   */
+  private $namespaces = [];
+
+  public function register($drupalRoot): void {
+    $finder = new DrupalFinder();
+    $finder->locateRoot($drupalRoot);
+
+    $drupalRoot = $finder->getDrupalRoot();
+    $drupalVendorRoot = $finder->getVendorDir();
+    if (! (bool) $drupalRoot || ! (bool) $drupalVendorRoot) {
+      throw new \RuntimeException("Unable to detect Drupal at $drupalRoot");
+    }
+
+    $this->drupalRoot = $drupalRoot;
+
+    $this->autoloader = include $drupalVendorRoot . '/autoload.php';
+
+    $this->serviceYamls['core'] = $drupalRoot . '/core/core.services.yml';
+    $this->serviceClassProviders['core'] = '\Drupal\Core\CoreServiceProvider';
+    $this->serviceMap['service_provider.core.service_provider'] = ['class' => $this->serviceClassProviders['core']];
+
+    $this->extensionDiscovery = new ExtensionDiscovery($this->drupalRoot);
+    $this->extensionDiscovery->setProfileDirectories([]);
+    $profiles = $this->extensionDiscovery->scan('profile');
+    $profile_directories = array_map(static function (Extension $profile) : string {
+      return $profile->getPath();
+    }, $profiles);
+    $this->extensionDiscovery->setProfileDirectories($profile_directories);
+
+    $this->moduleData = array_merge($this->extensionDiscovery->scan('module'), $profiles);
+    usort($this->moduleData, static function (Extension $a, Extension $b) {
+      return strpos($a->getName(), '_test') !== false ? 10 : 0;
+    });
+    $this->themeData = $this->extensionDiscovery->scan('theme');
+    $this->addTestNamespaces();
+    $this->addModuleNamespaces();
+    $this->addThemeNamespaces();
+    $this->registerPs4Namespaces($this->namespaces);
+    $this->loadLegacyIncludes();
+
+    // @todo stop requiring the bootstrap.php and just copy what is needed.
+    if (interface_exists(\PHPUnit\Framework\Test::class)) {
+      require_once $this->drupalRoot . '/core/tests/bootstrap.php';
+
+      // class_alias is not supported by OptimizedDirectorySourceLocator or AutoloadSourceLocator,
+      // so we manually load this PHPUnit compatibility trait that exists in Drupal 8.
+      $phpunitCompatTraitFilepath = $this->drupalRoot . '/core/tests/Drupal/Tests/PhpunitCompatibilityTrait.php';
+      if (file_exists($phpunitCompatTraitFilepath)) {
+        require_once $phpunitCompatTraitFilepath;
+        $this->autoloader->addClassMap(['Drupal\\Tests\\PhpunitCompatibilityTrait' => $phpunitCompatTraitFilepath]);
+      }
+    }
+
+    foreach ($this->moduleData as $extension) {
+      $this->loadExtension($extension);
+
+      $module_name = $extension->getName();
+      $module_dir = $this->drupalRoot . '/' . $extension->getPath();
+      // Add .install
+      if (file_exists($module_dir . '/' . $module_name . '.install')) {
+        $ignored_install_files = ['entity_test', 'entity_test_update', 'update_test_schema'];
+        if (!in_array($module_name, $ignored_install_files, true)) {
+          $this->loadAndCatchErrors($module_dir . '/' . $module_name . '.install');
+        }
+      }
+      // Add .post_update.php
+      if (file_exists($module_dir . '/' . $module_name . '.post_update.php')) {
+        $this->loadAndCatchErrors($module_dir . '/' . $module_name . '.post_update.php');
+      }
+      // Add misc .inc that are magically allowed via hook_hook_info.
+      $magic_hook_info_includes = [
+        'views',
+        'views_execution',
+        'tokens',
+        'search_api',
+        'pathauto',
+      ];
+      foreach ($magic_hook_info_includes as $hook_info_include) {
+        if (file_exists($module_dir . "/$module_name.$hook_info_include.inc")) {
+          $this->loadAndCatchErrors($module_dir . "/$module_name.$hook_info_include.inc");
+        }
+      }
+    }
+    foreach ($this->themeData as $extension) {
+      $this->loadExtension($extension);
+      $theme_dir = $this->drupalRoot . '/' . $extension->getPath();
+      $theme_settings_file = $theme_dir . '/theme-settings.php';
+      if (file_exists($theme_settings_file)) {
+        $this->loadAndCatchErrors($theme_settings_file);
+      }
+    }
+
+    if (class_exists(\Drush\Drush::class)) {
+      $reflect = new \ReflectionClass(\Drush\Drush::class);
+      if ($reflect->getFileName() !== false) {
+        $levels = 2;
+        if (\Drush\Drush::getMajorVersion() < 9) {
+          $levels = 3;
+        }
+        $drushDir = dirname($reflect->getFileName(), $levels);
+        /** @var \SplFileInfo $file */
+        foreach (Finder::findFiles('*.inc')->in($drushDir . '/includes') as $file) {
+          require_once $file->getPathname();
+        }
+      }
+    }
+
+    foreach ($this->serviceYamls as $extension => $serviceYaml) {
+      $yaml = Yaml::parseFile($serviceYaml);
+      // Weed out service files which only provide parameters.
+      if (!isset($yaml['services']) || !is_array($yaml['services'])) {
+        continue;
+      }
+      foreach ($yaml['services'] as $serviceId => $serviceDefinition) {
+        // Prevent \Nette\DI\ContainerBuilder::completeStatement from array_walk_recursive into the arguments
+        // and thinking these are real services for PHPStan's container.
+        if (isset($serviceDefinition['arguments']) && is_array($serviceDefinition['arguments'])) {
+          array_walk($serviceDefinition['arguments'], function (&$argument) : void {
+            if (is_array($argument) || !is_string($argument)) {
+              // @todo fix for @http_kernel.controller.argument_metadata_factory
+              $argument = '';
+            } else {
+              $argument = str_replace('@', '', $argument);
+            }
+          });
+        }
+        // @todo sanitize "calls" and "configurator" and "factory"
+        /**
+        jsonapi.params.enhancer:
+        class: Drupal\jsonapi\Routing\JsonApiParamEnhancer
+        calls:
+        - [setContainer, ['@service_container']]
+        tags:
+        - { name: route_enhancer }
+         */
+        unset($serviceDefinition['tags'], $serviceDefinition['calls'], $serviceDefinition['configurator'], $serviceDefinition['factory']);
+        $this->serviceMap[$serviceId] = $serviceDefinition;
+      }
+    }
+  }
+
+  protected function loadLegacyIncludes(): void
+  {
+    /** @var \SplFileInfo $file */
+    foreach (Finder::findFiles('*.inc')->in($this->drupalRoot . '/core/includes') as $file) {
+      require_once $file->getPathname();
+    }
+  }
+
+  protected function addTestNamespaces(): void
+  {
+    // Add core test namespaces.
+    $core_tests_dir = $this->drupalRoot . '/core/tests/Drupal';
+    $this->namespaces['Drupal\\BuildTests'] = $core_tests_dir . '/BuildTests';
+    $this->namespaces['Drupal\\FunctionalJavascriptTests'] = $core_tests_dir . '/FunctionalJavascriptTests';
+    $this->namespaces['Drupal\\FunctionalTests'] =  $core_tests_dir . '/FunctionalTests';
+    $this->namespaces['Drupal\\KernelTests'] = $core_tests_dir . '/KernelTests';
+    $this->namespaces['Drupal\\Tests'] = $core_tests_dir . '/Tests';
+    $this->namespaces['Drupal\\TestSite'] = $core_tests_dir . '/TestSite';
+    $this->namespaces['Drupal\\TestTools'] = $core_tests_dir . '/TestTools';
+    $this->namespaces['Drupal\\Tests\\TestSuites'] = $this->drupalRoot . '/core/tests/TestSuites';
+  }
+
+  protected function addModuleNamespaces(): void
+  {
+    foreach ($this->moduleData as $module) {
+      $module_name = $module->getName();
+      $module_dir = $this->drupalRoot . '/' . $module->getPath();
+      $this->namespaces["Drupal\\$module_name"] = $module_dir . '/src';
+
+      // Extensions can have a \Drupal\Tests\extension namespace for test cases, traits, and other classes such
+      // as those that extend \Drupal\TestSite\TestSetupInterface.
+      // @see drupal_phpunit_get_extension_namespaces()
+      $module_test_dir = $module_dir . '/tests/src';
+      if (is_dir($module_test_dir)) {
+        $this->namespaces["Drupal\\Tests\\$module_name"] = $module_test_dir;
+      }
+
+      $servicesFileName = $module_dir . '/' . $module_name . '.services.yml';
+      if (file_exists($servicesFileName)) {
+        $this->serviceYamls[$module_name] = $servicesFileName;
+      }
+      $camelized = $this->camelize($module_name);
+      $name = "{$camelized}ServiceProvider";
+      $class = "Drupal\\{$module_name}\\{$name}";
+
+      $this->serviceClassProviders[$module_name] = $class;
+      $serviceId = "service_provider.$module_name.service_provider";
+      $this->serviceMap[$serviceId] = ['class' => $class];
+    }
+  }
+  protected function addThemeNamespaces(): void
+  {
+    foreach ($this->themeData as $theme_name => $theme) {
+      $theme_dir = $this->drupalRoot . '/' . $theme->getPath();
+      $this->namespaces["Drupal\\$theme_name"] = $theme_dir . '/src';
+    }
+  }
+
+  protected function registerPs4Namespaces(array $namespaces): void
+  {
+    foreach ($namespaces as $prefix => $paths) {
+      if (is_array($paths)) {
+        foreach ($paths as $key => $value) {
+          $paths[$key] = $value;
+        }
+      }
+      $this->autoloader->addPsr4($prefix . '\\', $paths);
+    }
+  }
+  protected function loadExtension(Extension $extension): void
+  {
+    try {
+      $extension->load();
+    } catch (\Throwable $e) {
+      // Something prevented the extension file from loading.
+      // This can happen when drupal_get_path or drupal_get_filename are used outside of the scope of a function.
+    }
+  }
+
+  protected function loadAndCatchErrors(string $path): void
+  {
+    try {
+      require_once $path;
+    } catch (ContainerNotInitializedException $e) {
+      $path = str_replace(dirname($this->drupalRoot) . '/', '', $path);
+      // This can happen when drupal_get_path or drupal_get_filename are used outside of the scope of a function.
+      @trigger_error("$path invoked the Drupal container outside of the scope of a function or class method. It was not loaded.", E_USER_WARNING);
+    } catch (\Throwable $e) {
+      $path = str_replace(dirname($this->drupalRoot) . '/', '', $path);
+      // Something prevented the extension file from loading.
+      @trigger_error("$path failed loading due to {$e->getMessage()}", E_USER_WARNING);
+    }
+  }
+
+  protected function camelize(string $id): string
+  {
+    return strtr(ucwords(strtr($id, ['_' => ' ', '.' => '_ ', '\\' => '_ '])), [' ' => '']);
+  }
+
+}

--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -1,23 +1,35 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Wunderio\GrumPHP\Drupal;
 
-use Drupal\Core\DependencyInjection\ContainerNotInitializedException;
 use DrupalFinder\DrupalFinder;
+use Drupal\Core\DependencyInjection\ContainerNotInitializedException;
+use Drush\Drush;
 use Nette\Utils\Finder;
-use PHPStan\DependencyInjection\Container;
-use PHPStan\Drupal\ExtensionDiscovery;
-use PHPStan\Drupal\ServiceMap;
+use PHPUnit\Framework\Test;
 use Symfony\Component\Yaml\Yaml;
-use PHPStan\Drupal\Extension;
+use mglaman\PHPStanDrupal\Drupal\Extension;
+use mglaman\PHPStanDrupal\Drupal\ExtensionDiscovery;
 
+/**
+ * Drupal autoloader for allowing Psalm to scan code.
+ *
+ * Code re-used from https://github.com/mglaman/phpstan-drupal/blob/main/src/Drupal/DrupalAutoloader.php.
+ */
 class DrupalAutoloader {
+
   /**
+   * Drupal autoloader.
+   *
    * @var \Composer\Autoload\ClassLoader
    */
   private $autoloader;
 
   /**
+   * Path to Drupal root.
+   *
    * @var string
    */
   private $drupalRoot;
@@ -25,49 +37,65 @@ class DrupalAutoloader {
   /**
    * List of available modules.
    *
-   * @var Extension[]
+   * @var array
    */
   protected $moduleData = [];
 
   /**
    * List of available themes.
    *
-   * @var Extension[]
+   * @var array
    */
   protected $themeData = [];
 
   /**
-   * @var array<array<string, string>>
+   * Array of Drupal service mapping.
+   *
+   * @var array
    */
   private $serviceMap = [];
 
   /**
-   * @var array<string, string>
+   * Array of Drupal service yml files.
+   *
+   * @var array
    */
   private $serviceYamls = [];
 
   /**
-   * @var array<string, string>
+   * Array of service class providers.
+   *
+   * @var array
    */
   private $serviceClassProviders = [];
 
   /**
-   * @var ?\Wunderio\GrumPHP\Drupal\ExtensionDiscovery
+   * ExtensionDiscovery object.
+   *
+   * @var \mglaman\PHPStanDrupal\Drupal\ExtensionDiscovery
    */
   private $extensionDiscovery;
 
   /**
+   * Array of Drupal namespaces.
+   *
    * @var array
    */
   private $namespaces = [];
 
-  public function register($drupalRoot): void {
+  /**
+   * Load in Drupal code from defined path.
+   *
+   * @param string $drupalRoot
+   *   Path to Drupal root.
+   */
+  public function register(string $drupalRoot): void {
     $finder = new DrupalFinder();
     $finder->locateRoot($drupalRoot);
 
     $drupalRoot = $finder->getDrupalRoot();
     $drupalVendorRoot = $finder->getVendorDir();
-    if (! (bool) $drupalRoot || ! (bool) $drupalVendorRoot) {
+    if (!(bool) $drupalRoot || !(bool) $drupalVendorRoot) {
       throw new \RuntimeException("Unable to detect Drupal at $drupalRoot");
     }
 
@@ -82,14 +110,16 @@ class DrupalAutoloader {
     $this->extensionDiscovery = new ExtensionDiscovery($this->drupalRoot);
     $this->extensionDiscovery->setProfileDirectories([]);
     $profiles = $this->extensionDiscovery->scan('profile');
+    // phpcs:ignore PHPCS_SecurityAudit.BadFunctions.CallbackFunctions.WarnCallbackFunctions
     $profile_directories = array_map(static function (Extension $profile) : string {
       return $profile->getPath();
     }, $profiles);
     $this->extensionDiscovery->setProfileDirectories($profile_directories);
 
     $this->moduleData = array_merge($this->extensionDiscovery->scan('module'), $profiles);
+    // phpcs:ignore PHPCS_SecurityAudit.BadFunctions.CallbackFunctions.WarnCallbackFunctions
     usort($this->moduleData, static function (Extension $a, Extension $b) {
-      return strpos($a->getName(), '_test') !== false ? 10 : 0;
+      return strpos($a->getName(), '_test') !== FALSE ? 10 : 0;
     });
     $this->themeData = $this->extensionDiscovery->scan('theme');
     $this->addTestNamespaces();
@@ -99,13 +129,15 @@ class DrupalAutoloader {
     $this->loadLegacyIncludes();
 
     // @todo stop requiring the bootstrap.php and just copy what is needed.
-    if (interface_exists(\PHPUnit\Framework\Test::class)) {
+    if (interface_exists(Test::class)) {
       require_once $this->drupalRoot . '/core/tests/bootstrap.php';
 
-      // class_alias is not supported by OptimizedDirectorySourceLocator or AutoloadSourceLocator,
-      // so we manually load this PHPUnit compatibility trait that exists in Drupal 8.
+      // class_alias is not supported by OptimizedDirectorySourceLocator
+      // or AutoloadSourceLocator, so we manually load this PHPUnit
+      // compatibility trait that exists in Drupal 8.
       $phpunitCompatTraitFilepath = $this->drupalRoot . '/core/tests/Drupal/Tests/PhpunitCompatibilityTrait.php';
       if (file_exists($phpunitCompatTraitFilepath)) {
+        // phpcs:ignore PHPCS_SecurityAudit.Misc.IncludeMismatch.ErrMiscIncludeMismatchNoExt
         require_once $phpunitCompatTraitFilepath;
         $this->autoloader->addClassMap(['Drupal\\Tests\\PhpunitCompatibilityTrait' => $phpunitCompatTraitFilepath]);
       }
@@ -116,14 +148,18 @@ class DrupalAutoloader {
 
       $module_name = $extension->getName();
       $module_dir = $this->drupalRoot . '/' . $extension->getPath();
-      // Add .install
+      // Add .install.
       if (file_exists($module_dir . '/' . $module_name . '.install')) {
-        $ignored_install_files = ['entity_test', 'entity_test_update', 'update_test_schema'];
-        if (!in_array($module_name, $ignored_install_files, true)) {
+        $ignored_install_files = [
+          'entity_test',
+          'entity_test_update',
+          'update_test_schema',
+        ];
+        if (!in_array($module_name, $ignored_install_files, TRUE)) {
           $this->loadAndCatchErrors($module_dir . '/' . $module_name . '.install');
         }
       }
-      // Add .post_update.php
+      // Add .post_update.php.
       if (file_exists($module_dir . '/' . $module_name . '.post_update.php')) {
         $this->loadAndCatchErrors($module_dir . '/' . $module_name . '.post_update.php');
       }
@@ -150,16 +186,17 @@ class DrupalAutoloader {
       }
     }
 
-    if (class_exists(\Drush\Drush::class)) {
-      $reflect = new \ReflectionClass(\Drush\Drush::class);
-      if ($reflect->getFileName() !== false) {
+    if (class_exists(Drush::class)) {
+      $reflect = new \ReflectionClass(Drush::class);
+      if ($reflect->getFileName() !== FALSE) {
         $levels = 2;
-        if (\Drush\Drush::getMajorVersion() < 9) {
+        if (Drush::getMajorVersion() < 9) {
           $levels = 3;
         }
         $drushDir = dirname($reflect->getFileName(), $levels);
         /** @var \SplFileInfo $file */
         foreach (Finder::findFiles('*.inc')->in($drushDir . '/includes') as $file) {
+          // phpcs:ignore PHPCS_SecurityAudit.Misc.IncludeMismatch.ErrMiscIncludeMismatchNoExt
           require_once $file->getPathname();
         }
       }
@@ -172,26 +209,29 @@ class DrupalAutoloader {
         continue;
       }
       foreach ($yaml['services'] as $serviceId => $serviceDefinition) {
-        // Prevent \Nette\DI\ContainerBuilder::completeStatement from array_walk_recursive into the arguments
+        // Prevent \Nette\DI\ContainerBuilder::completeStatement from
+        // array_walk_recursive into the arguments
         // and thinking these are real services for PHPStan's container.
         if (isset($serviceDefinition['arguments']) && is_array($serviceDefinition['arguments'])) {
+          // phpcs:ignore PHPCS_SecurityAudit.BadFunctions.CallbackFunctions.WarnCallbackFunctions
           array_walk($serviceDefinition['arguments'], function (&$argument) : void {
             if (is_array($argument) || !is_string($argument)) {
               // @todo fix for @http_kernel.controller.argument_metadata_factory
               $argument = '';
-            } else {
+            }
+            else {
               $argument = str_replace('@', '', $argument);
             }
           });
         }
         // @todo sanitize "calls" and "configurator" and "factory"
-        /**
-        jsonapi.params.enhancer:
-        class: Drupal\jsonapi\Routing\JsonApiParamEnhancer
-        calls:
-        - [setContainer, ['@service_container']]
-        tags:
-        - { name: route_enhancer }
+        /*
+         * jsonapi.params.enhancer:
+         * class: Drupal\jsonapi\Routing\JsonApiParamEnhancer
+         * calls:
+         * - [setContainer, ['@service_container']]
+         * tags:
+         * - { name: route_enhancer }
          */
         unset($serviceDefinition['tags'], $serviceDefinition['calls'], $serviceDefinition['configurator'], $serviceDefinition['factory']);
         $this->serviceMap[$serviceId] = $serviceDefinition;
@@ -199,21 +239,25 @@ class DrupalAutoloader {
     }
   }
 
-  protected function loadLegacyIncludes(): void
-  {
+  /**
+   * Load legacy includes.
+   */
+  protected function loadLegacyIncludes(): void {
     /** @var \SplFileInfo $file */
     foreach (Finder::findFiles('*.inc')->in($this->drupalRoot . '/core/includes') as $file) {
+      // phpcs:ignore PHPCS_SecurityAudit.Misc.IncludeMismatch.ErrMiscIncludeMismatchNoExt
       require_once $file->getPathname();
     }
   }
 
-  protected function addTestNamespaces(): void
-  {
-    // Add core test namespaces.
+  /**
+   * Add core test namespaces.
+   */
+  protected function addTestNamespaces(): void {
     $core_tests_dir = $this->drupalRoot . '/core/tests/Drupal';
     $this->namespaces['Drupal\\BuildTests'] = $core_tests_dir . '/BuildTests';
     $this->namespaces['Drupal\\FunctionalJavascriptTests'] = $core_tests_dir . '/FunctionalJavascriptTests';
-    $this->namespaces['Drupal\\FunctionalTests'] =  $core_tests_dir . '/FunctionalTests';
+    $this->namespaces['Drupal\\FunctionalTests'] = $core_tests_dir . '/FunctionalTests';
     $this->namespaces['Drupal\\KernelTests'] = $core_tests_dir . '/KernelTests';
     $this->namespaces['Drupal\\Tests'] = $core_tests_dir . '/Tests';
     $this->namespaces['Drupal\\TestSite'] = $core_tests_dir . '/TestSite';
@@ -221,14 +265,17 @@ class DrupalAutoloader {
     $this->namespaces['Drupal\\Tests\\TestSuites'] = $this->drupalRoot . '/core/tests/TestSuites';
   }
 
-  protected function addModuleNamespaces(): void
-  {
+  /**
+   * Add Drupal module namespaces.
+   */
+  protected function addModuleNamespaces(): void {
     foreach ($this->moduleData as $module) {
       $module_name = $module->getName();
       $module_dir = $this->drupalRoot . '/' . $module->getPath();
       $this->namespaces["Drupal\\$module_name"] = $module_dir . '/src';
 
-      // Extensions can have a \Drupal\Tests\extension namespace for test cases, traits, and other classes such
+      // Extensions can have a \Drupal\Tests\extension namespace for test
+      // cases, traits, and other classes such
       // as those that extend \Drupal\TestSite\TestSetupInterface.
       // @see drupal_phpunit_get_extension_namespaces()
       $module_test_dir = $module_dir . '/tests/src';
@@ -249,16 +296,24 @@ class DrupalAutoloader {
       $this->serviceMap[$serviceId] = ['class' => $class];
     }
   }
-  protected function addThemeNamespaces(): void
-  {
+
+  /**
+   * Add Drupal theme namespaces.
+   */
+  protected function addThemeNamespaces(): void {
     foreach ($this->themeData as $theme_name => $theme) {
       $theme_dir = $this->drupalRoot . '/' . $theme->getPath();
       $this->namespaces["Drupal\\$theme_name"] = $theme_dir . '/src';
     }
   }
 
-  protected function registerPs4Namespaces(array $namespaces): void
-  {
+  /**
+   * Register PS4 namespaces.
+   *
+   * @param array $namespaces
+   *   An array of namespaces to load.
+   */
+  protected function registerPs4Namespaces(array $namespaces): void {
     foreach ($namespaces as $prefix => $paths) {
       if (is_array($paths)) {
         foreach ($paths as $key => $value) {
@@ -268,33 +323,62 @@ class DrupalAutoloader {
       $this->autoloader->addPsr4($prefix . '\\', $paths);
     }
   }
-  protected function loadExtension(Extension $extension): void
-  {
+
+  /**
+   * Loads in extensions (modules, themes, etc).
+   *
+   * Wrapper for \mglaman\PHPStanDrupal\Drupal\Extension->load().
+   *
+   * @param \mglaman\PHPStanDrupal\Drupal\Extension $extension
+   *   Extension object.
+   */
+  protected function loadExtension(Extension $extension): void {
     try {
       $extension->load();
-    } catch (\Throwable $e) {
+    }
+    catch (\Throwable $e) {
       // Something prevented the extension file from loading.
-      // This can happen when drupal_get_path or drupal_get_filename are used outside of the scope of a function.
+      // This can happen when drupal_get_path or drupal_get_filename are used
+      // outside the scope of a function.
     }
   }
 
-  protected function loadAndCatchErrors(string $path): void
-  {
+  /**
+   * Wrapper for require_once() that catches errors.
+   *
+   * @param string $path
+   *   Path to file.
+   */
+  protected function loadAndCatchErrors(string $path): void {
     try {
+      // phpcs:ignore PHPCS_SecurityAudit.Misc.IncludeMismatch.ErrMiscIncludeMismatchNoExt
       require_once $path;
-    } catch (ContainerNotInitializedException $e) {
+    }
+    catch (ContainerNotInitializedException $e) {
       $path = str_replace(dirname($this->drupalRoot) . '/', '', $path);
-      // This can happen when drupal_get_path or drupal_get_filename are used outside of the scope of a function.
+      // This can happen when drupal_get_path or drupal_get_filename are used
+      // outside the scope of a function.
       @trigger_error("$path invoked the Drupal container outside of the scope of a function or class method. It was not loaded.", E_USER_WARNING);
-    } catch (\Throwable $e) {
+    }
+    catch (\Throwable $e) {
       $path = str_replace(dirname($this->drupalRoot) . '/', '', $path);
       // Something prevented the extension file from loading.
       @trigger_error("$path failed loading due to {$e->getMessage()}", E_USER_WARNING);
     }
   }
 
-  protected function camelize(string $id): string
-  {
+  /**
+   * Camelizes a string.
+   *
+   * @todo Should we use method from Symfony\Component\DependencyInjection\Container instead?
+   *
+   * @param string $id
+   *   A string to camelize.
+   *
+   * @return string
+   *   The camelized string.
+   */
+  protected function camelize(string $id): string {
     return strtr(ucwords(strtr($id, ['_' => ' ', '.' => '_ ', '\\' => '_ '])), [' ' => '']);
   }
 

--- a/src/Task/Psalm/PsalmExtensionLoader.php
+++ b/src/Task/Psalm/PsalmExtensionLoader.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Wunderio\GrumPHP\Task\Psalm;
+
+use Wunderio\GrumPHP\Task\AbstractExternalExtensionLoader;
+
+/**
+ * Class PsalmExtensionLoader.
+ *
+ * Register Psalm task in the service container of GrumPHP.
+ *
+ * @package Wunderio\GrumPHP\Task
+ */
+class PsalmExtensionLoader extends AbstractExternalExtensionLoader {}

--- a/src/Task/Psalm/PsalmTask.php
+++ b/src/Task/Psalm/PsalmTask.php
@@ -27,6 +27,7 @@ class PsalmTask extends AbstractMultiPathProcessingTask {
     $arguments->addOptionalArgument('--report=%s', $config['report']);
     $arguments->addOptionalArgument('--no-cache', $config['no_cache']);
     $arguments->addOptionalArgument('--threads=%d', $config['threads']);
+    $arguments->add('--find-unused-code');
     $arguments->addOptionalBooleanArgument('--show-info=%s', $config['show_info'], 'true', 'false');
 
     foreach ($files as $file) {

--- a/src/Task/Psalm/PsalmTask.php
+++ b/src/Task/Psalm/PsalmTask.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Wunderio\GrumPHP\Task\Psalm;
+
+use GrumPHP\Collection\ProcessArgumentsCollection;
+use Wunderio\GrumPHP\Task\AbstractMultiPathProcessingTask;
+
+/**
+ * Class PsalmTask.
+ *
+ * Psalm task.
+ *
+ * @package Wunderio\GrumPHP\Task
+ */
+class PsalmTask extends AbstractMultiPathProcessingTask {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildArguments(iterable $files): ProcessArgumentsCollection {
+    $arguments = $this->processBuilder->createArgumentsForCommand('psalm');
+    $config = $this->getConfig()->getOptions();
+    $arguments->addOptionalArgument('--output-format=%s', $config['output_format']);
+    $arguments->addOptionalArgument('--config=%s', $config['config']);
+    $arguments->addOptionalArgument('--report=%s', $config['report']);
+    $arguments->addOptionalArgument('--no-cache', $config['no_cache']);
+    $arguments->addOptionalArgument('--threads=%d', $config['threads']);
+    $arguments->addOptionalBooleanArgument('--show-info=%s', $config['show_info'], 'true', 'false');
+
+    foreach ($files as $file) {
+      $arguments->add($file);
+    }
+
+    return $arguments;
+  }
+
+}

--- a/src/Task/Psalm/PsalmTask.php
+++ b/src/Task/Psalm/PsalmTask.php
@@ -26,7 +26,14 @@ class PsalmTask extends AbstractMultiPathProcessingTask {
     $arguments->addOptionalArgument('--config=%s', $config['config']);
     $arguments->addOptionalArgument('--report=%s', $config['report']);
     $arguments->addOptionalArgument('--no-cache', $config['no_cache']);
-    $arguments->addOptionalArgument('--threads=%d', $config['threads']);
+    if (!extension_loaded('pcntl') || !extension_loaded('posix')) {
+      // Psalm will error if we don't have pcntl or posix installed as
+      // we have increased the threads in our default configs.
+      $arguments->addOptionalArgument('--threads=%d', 1);
+    }
+    else {
+      $arguments->addOptionalArgument('--threads=%d', $config['threads']);
+    }
     $arguments->add('--find-unused-code');
     $arguments->addOptionalBooleanArgument('--show-info=%s', $config['show_info'], 'true', 'false');
 

--- a/src/Task/Psalm/README.md
+++ b/src/Task/Psalm/README.md
@@ -1,0 +1,26 @@
+# psalm
+
+Psalm is a static analysis tool that attempts to dig into your program and
+find as many type-related bugs as possible..
+
+### grumphp.yml (with current defaults):
+````yml
+grumphp:
+    tasks:
+        psalm:
+            config: 'psalm.xml'
+            ignore_patterns:
+                - '/vendor/'
+                - '/node_modules/'
+                - '/core/'
+                - '/libraries/'
+            extensions: ['php', 'inc', 'module', 'install', 'theme']
+            run_on: ['web/modules/custom', 'web/themes/custom']
+            no_cache: false
+            report: ~
+            output_format: null
+            threads: 1
+            show_info: false
+    extensions:
+        - Wunderio\GrumPHP\Task\Psalm\PsalmExtensionLoader
+````

--- a/src/Task/tasks.yml
+++ b/src/Task/tasks.yml
@@ -276,7 +276,7 @@ Wunderio\GrumPHP\Task\Psalm\PsalmTask:
       defaults: null
       allowed_types: ['string', 'null' ]
     threads:
-      defaults: 1
+      defaults: 6
       allowed_types: ['int']
     show_info:
       defaults: false

--- a/src/Task/tasks.yml
+++ b/src/Task/tasks.yml
@@ -246,3 +246,38 @@ Wunderio\GrumPHP\Task\JsonLint\JsonLintTask:
     detect_key_conflicts:
       defaults: false
       allowed_types: ['bool']
+Wunderio\GrumPHP\Task\Psalm\PsalmTask:
+  options:
+    # We read psalm.xml from project root so file paths would not begin with ../../../../web/ in report.
+    config:
+      defaults: 'psalm.xml'
+      allowed_types: ['string']
+    ignore_patterns:
+      defaults:
+        - '/vendor/'
+        - '/node_modules/'
+        - '/core/'
+        - '/libraries/'
+        - '/contrib/'
+      allowed_types: ['array']
+    extensions:
+      defaults: ['php', 'inc', 'module', 'install', 'theme']
+      allowed_types: ['array']
+    run_on:
+      defaults: ['web/modules/custom', 'web/themes/custom']
+      allowed_types: ['array']
+    no_cache:
+      defaults: false
+      allowed_types: ['bool']
+    report:
+      defaults: ~
+      allowed_types: ['string', 'null' ]
+    output_format:
+      defaults: null
+      allowed_types: ['string', 'null' ]
+    threads:
+      defaults: 1
+      allowed_types: ['int']
+    show_info:
+      defaults: false
+      allowed_types: ['bool']


### PR DESCRIPTION
You can try this out on Drupal 9 project:


1. 
    
`composer require wunderio/code-quality:dev-feature/62-add-psalm-task --dev`

or in Lando prefix with _lando_. Psalm requires PHP's mbstring and in my experience I was missing it locally but Lando had it.

    lando composer require wunderio/code-quality:dev-feature/62-add-psalm-task --dev

Lock files can be tricky and every project is different. On my 9.2.6 installation I did this:

    lando composer require wunderio/code-quality:dev-feature/62-add-psalm-task composer/xdebug-handler:1.4.6 composer/composer:2.0.2  --dev

2. Check that first line in grumphp.yml is grumphp: and not parameters:

![image](https://user-images.githubusercontent.com/492375/134767273-fc18d89b-16aa-4a4b-a951-79ae54fd04b1.png)

3. In Grumphp add psalm task and extension lines ("psalm: ~" under "tasks:" and "- Wunderio\GrumPHP\Task\Psalm\PsalmExtensionLoader" under "extensions:")

![image](https://user-images.githubusercontent.com/492375/134767307-2fe7213d-a35e-4d38-9006-a1e43598a842.png)

4. Copy the psalm.xml config to project root

    `cp vendor/wunderio/code-quality/config/psalm.xml ./psalm.xml`


5. You might see issues with tests not finding dependencies. ERROR: MissingDependency - web/modules/custom/redirect_old_tua/tests/src/HomePageTest.php:13:28 - Drupal\Tests\BrowserTestBase depends on class or interface phpunit\framework\testcase that does not exist (see https://psalm.dev/157)
class HomePageTest extends BrowserTestBase {

For that install testing Drupals testing support:

    composer require drupal/core-dev:X.X.X --dev

6. As I don't have php locally I'm also using Landos php with this grumphp config:

    grumphp:
      git_hook_variables:
        EXEC_GRUMPHP_COMMAND: 'lando php'
    
and re-init grumphp

    lando grumphp git:init

Where X.X.X is your current core version.