### PR TITLE
#69 Use local phpstan.neon

### DIFF
--- a/src/Task/tasks.yml
+++ b/src/Task/tasks.yml
@@ -185,7 +185,7 @@ Wunderio\GrumPHP\Task\PhpStan\PhpStanTask:
       defaults: ~
       allowed_types: ['string', 'null']
     configuration:
-      defaults: 'vendor/wunderio/code-quality/config/phpstan.neon'
+      defaults: 'phpstan.neon'
       allowed_types: ['string', 'null']
     memory_limit:
       defaults: ~


### PR DESCRIPTION
Before this fix see that editing vendor/wunderio/code-quality/config/phpstan.neon configures PHPStan. After the fix, phpstan.neon in the root of your project configures PHPStan. 

To test

    composer require wunderio/code-quality:dev-feature/69-Use-local-phpstan.neon

Do some changes in phpstan.neon in the file in your project root and run grumphp

     ./vendor/bin/grumphp run

