### PR TITLE
Feature/#79 change the default php code checker version to 8.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   # Install all dependencies and run check tasks.
   build_and_test:
     docker:
-      - image: circleci/php:7.4-cli-node
+      - image: circleci/php:8.0-cli-node
     steps:
       # Check out source code.
       - checkout

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ its [documentation](https://github.com/phpro/grumphp/blob/master/README.md#confi
 
 ## Checks performed
 
-This repository currently has following checks:
+This repository currently has the following checks:
 
 * Shell script exec bits - [check_file_permissions](src/Task/CheckFilePermissions/README.md)
 * PHP Drupal CS and PHP Code security  - [phpcs](src/Task/Phpcs/README.md)
-* PHP 7.3 Compatibility - [php_compatibility](src/Task/PhpCompatibility/README.md)
+* PHP 8.0 Compatibility - [php_compatibility](src/Task/PhpCompatibility/README.md)
 * PHP syntax - [php_check_syntax](src/Task/PhpCheckSyntax/README.md)
 * Cognitive complexity and other ecs sniffs - [ecs](src/Task/Ecs/README.md)
 * Yaml syntax - [yaml_lint](src/Task/YamlLint/README.md)

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
         "mglaman/phpstan-drupal": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "vimeo/psalm": "^4",
-        "nette/finder": "^2.5"
+        "nette/finder": "^2.5",
+        "symfony/finder": "^4.4"
     },
     "autoload": {
         "psr-4": {

--- a/src/Task/PhpCompatibility/README.md
+++ b/src/Task/PhpCompatibility/README.md
@@ -7,14 +7,14 @@ Check if files are compatible with X version of PHP.
 parameters:
     tasks:
         php_compatibility:
-            ignore_patterns: 
+            ignore_patterns:
                 - '/vendor/'
                 - '/node_modules/'
                 - '/core/'
                 - '/libraries/'
             extensions: ['php', 'inc', 'module', 'install', 'theme']
             run_on: ['.']
-            testVersion: '7.3'
+            testVersion: '8.0'
             standard: 'PHPCompatibility'
             parallel: 20
     extensions:

--- a/src/Task/tasks.yml
+++ b/src/Task/tasks.yml
@@ -99,7 +99,7 @@ Wunderio\GrumPHP\Task\PhpCompatibility\PhpCompatibilityTask:
       defaults: ['.']
       allowed_types: ['array']
     testVersion:
-      defaults: '7.3'
+      defaults: '8.0'
       allowed_types: ['string']
     standard:
       defaults: 'PHPCompatibility'

--- a/tests/PhpCompatibility/PhpCompatibilityTaskTest.php
+++ b/tests/PhpCompatibility/PhpCompatibilityTaskTest.php
@@ -47,7 +47,7 @@ final class PhpCompatibilityTaskTest extends TestCase {
     $stub->method('getConfig')->willReturn($taskConfig);
     $taskConfig->method('getOptions')->willReturn([
       'standard' => 'php-compatibility.xm',
-      'testVersion' => '7.3',
+      'testVersion' => '8.0',
       'extensions' => ['php'],
       'run_on' => ['.'],
       'ignore_patterns' => ['/vendor/'],


### PR DESCRIPTION
This change will update the code checker version to 8.0.
But also this is small move towards PHP 8.0 as we'll change the circleci to run in PHP 8.0 and add fix so it would not break in PHP 8.x environment (by fetching too new package symfony/finder package).
