### PR TITLE
#86 Add 1 ruleset to group all Wunder rulesets.

### DIFF
--- a/rulesets/WunderAll/ruleset.xml
+++ b/rulesets/WunderAll/ruleset.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!-- See http://pear.php.net/manual/en/package.php.php-codesniffer.annotated-ruleset.php -->
+<ruleset name="WunderAll">
+    <description>Group together all Wunder rules for easier inclusion. Also in PHPStorm it's not possible to choose multiple rules.</description>
+
+    <rule ref="WunderDrupal" />
+    <rule ref="WunderSecurity" />
+</ruleset>


### PR DESCRIPTION
Now you could choose WunderAll in PHPStorm. Bottom right option "Coding standard"

![image](https://user-images.githubusercontent.com/492375/201119251-4b48257d-fd98-4ed2-a410-9abb2bfb8600.png)


