### PR TITLE
Feature/#93 add phpstan extension installer

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -4,9 +4,18 @@ config:
   php: '8.1'
   xdebug: true
 
+services:
+  appserver:
+    build:
+      - composer install
+
 tooling:
   phpunit:
     service: appserver
     description: Run Drupal PHPUnit tests. Run 'lando phpunit --help' for more information.
     cmd:
       - "/app/.lando/tooling-phpunit.sh"
+  grumphp:
+    service: appserver
+    description: Runs grumphp commands
+    cmd: /app/.lando/tooling-grumphp.sh

--- a/.lando/tooling-grumphp.sh
+++ b/.lando/tooling-grumphp.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+#
+# Helper script to run GrumPHP.
+#
+
+set -exuo pipefail
+export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/app/vendor/bin
+
+cd /app
+./vendor/bin/grumphp "$@"

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
         "squizlabs/php_codesniffer": "^3.4",
         "dealerdirect/phpcodesniffer-composer-installer": "*",
         "mglaman/phpstan-drupal": "^1.1",
+        "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "vimeo/psalm": "^4",
         "nette/finder": "^2.5",

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,8 @@
     "config": {
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true,
-            "phpro/grumphp": true
+            "phpro/grumphp": true,
+            "phpstan/extension-installer": true
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -63,5 +63,12 @@
             "phpro/grumphp": true,
             "phpstan/extension-installer": true
         }
+    },
+    "extra": {
+        "phpstan/extension-installer": {
+            "ignore": [
+                "mglaman/phpstan-drupal"
+            ]
+        }
     }
 }

--- a/config/phpstan.neon
+++ b/config/phpstan.neon
@@ -7,6 +7,3 @@ parameters:
 		- '#Plugin definitions cannot be altered.#'
 		- '#Missing cache backend declaration for performance.#'
 		- '#Plugin manager has cache backend specified but does not declare cache tags.#'
-includes:
-	- %currentWorkingDirectory%/vendor/mglaman/phpstan-drupal/extension.neon
-	- %currentWorkingDirectory%/vendor/phpstan/phpstan-deprecation-rules/rules.neon

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,5 +7,3 @@ parameters:
 		- '#Plugin definitions cannot be altered.#'
 		- '#Missing cache backend declaration for performance.#'
 		- '#Plugin manager has cache backend specified but does not declare cache tags.#'
-includes:
-  - 'vendor/phpstan/phpstan-deprecation-rules/rules.neon'


### PR DESCRIPTION
## Description

Drupal 10 code-dev requires this package phpstan/extension-installer that loads php_stan .neon files automatically. Currently we have them like on the screenshot.

This PR requires adds the requirement to Code Quality and removes the lines from default config. This way we're more in sync with Drupal 10 and automatic loading seems nice feature.

Here's more information on the package https://github.com/phpstan/extension-installer

## Screenshots

![236185511-f7f457e1-f48a-4b59-923b-1b8d9c218c04](https://user-images.githubusercontent.com/492375/236190205-47246453-a323-4995-bfaa-a40afc8d3658.png)

## Testing notes

Install via composer:

    lando composer require wunderio/code-quality:dev-feature/93-add-phpstan-extension-installer --dev

Copy over the new .neon file

    cp vendor/wunderio/code-quality/config/phpstan.neon ./phpstan.neon

Optionally disable other tasks in grumphp.yml for faster test run:
```
grumphp:
  stop_on_failure: true
  process_timeout: 300
  ascii:
    failed: ~
    succeeded: ~
  tasks:
#    php_compatibility: ~
#    check_file_permissions: ~
#    php_check_syntax: ~
#    phpcs: ~
    php_stan: ~
#    yaml_lint: ~
#    json_lint: ~
#    psalm: ~
  extensions:
    - Wunderio\GrumPHP\Task\PhpCompatibility\PhpCompatibilityExtensionLoader
    - Wunderio\GrumPHP\Task\PhpCheckSyntax\PhpCheckSyntaxExtensionLoader
    - Wunderio\GrumPHP\Task\CheckFilePermissions\CheckFilePermissionsExtensionLoader
    - Wunderio\GrumPHP\Task\Ecs\EcsExtensionLoader
    - Wunderio\GrumPHP\Task\Phpcs\PhpcsExtensionLoader
    - Wunderio\GrumPHP\Task\PhpStan\PhpStanExtensionLoader
    - Wunderio\GrumPHP\Task\YamlLint\YamlLintExtensionLoader
    - Wunderio\GrumPHP\Task\JsonLint\JsonLintExtensionLoader
    - Wunderio\GrumPHP\Task\Psalm\PsalmExtensionLoader

```

Depending on your environment, run grumphp on your codebase

    lando grumphp run

or 

    lando ssh
    ./vendor/bin/grumphp run
