### PR TITLE
#72 Add tomasvotruba/cognitive-complexity.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   # Install all dependencies and run check tasks.
   build_and_test:
     docker:
-      - image: cimg/php:8.1
+      - image: cimg/php:8.1.18
     steps:
       # Check out source code.
       - checkout

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,8 @@
         "vimeo/psalm": "^4",
         "nette/finder": "^2.5",
         "symfony/finder": "^4.4 || ^5.3 || ^6",
-        "tomasvotruba/cognitive-complexity": "^0.1.1"
+        "tomasvotruba/cognitive-complexity": "^0.1.1",
+        "webflo/drupal-finder": "^1.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "vimeo/psalm": "^4",
         "nette/finder": "^2.5",
-        "symfony/finder": "^4.4 || ^5.3 || ^6"
+        "symfony/finder": "^4.4 || ^5.3 || ^6",
+        "tomasvotruba/cognitive-complexity": "^0.1.1"
     },
     "autoload": {
         "psr-4": {

--- a/config/phpstan.neon
+++ b/config/phpstan.neon
@@ -9,4 +9,4 @@ parameters:
 		- '#Plugin manager has cache backend specified but does not declare cache tags.#'
 	cognitive_complexity:
 		class: 50
-		function: 16
+		function: 15

--- a/config/phpstan.neon
+++ b/config/phpstan.neon
@@ -7,3 +7,6 @@ parameters:
 		- '#Plugin definitions cannot be altered.#'
 		- '#Missing cache backend declaration for performance.#'
 		- '#Plugin manager has cache backend specified but does not declare cache tags.#'
+	cognitive_complexity:
+		class: 50
+		function: 16

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,4 +9,4 @@ parameters:
 		- '#Plugin manager has cache backend specified but does not declare cache tags.#'
 	cognitive_complexity:
 		class: 50
-		function: 16
+		function: 15

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,3 +7,6 @@ parameters:
 		- '#Plugin definitions cannot be altered.#'
 		- '#Missing cache backend declaration for performance.#'
 		- '#Plugin manager has cache backend specified but does not declare cache tags.#'
+	cognitive_complexity:
+		class: 50
+		function: 16

--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Wunderio\GrumPHP\Drupal;
 
 use DrupalFinder\DrupalFinder;
-use Drupal\Core\DependencyInjection\ContainerNotInitializedException;
 use Drush\Drush;
 use Nette\Utils\Finder;
 use PHPUnit\Framework\Test;
@@ -18,70 +17,7 @@ use mglaman\PHPStanDrupal\Drupal\ExtensionDiscovery;
  *
  * Code re-used from https://github.com/mglaman/phpstan-drupal/blob/main/src/Drupal/DrupalAutoloader.php.
  */
-class DrupalAutoloader {
-
-  /**
-   * Drupal autoloader.
-   *
-   * @var \Composer\Autoload\ClassLoader
-   */
-  private $autoloader;
-
-  /**
-   * Path to Drupal root.
-   *
-   * @var string
-   */
-  private $drupalRoot;
-
-  /**
-   * List of available modules.
-   *
-   * @var array
-   */
-  protected $moduleData = [];
-
-  /**
-   * List of available themes.
-   *
-   * @var array
-   */
-  protected $themeData = [];
-
-  /**
-   * Array of Drupal service mapping.
-   *
-   * @var array
-   */
-  private $serviceMap = [];
-
-  /**
-   * Array of Drupal service yml files.
-   *
-   * @var array
-   */
-  private $serviceYamls = [];
-
-  /**
-   * Array of service class providers.
-   *
-   * @var array
-   */
-  private $serviceClassProviders = [];
-
-  /**
-   * ExtensionDiscovery object.
-   *
-   * @var \mglaman\PHPStanDrupal\Drupal\ExtensionDiscovery
-   */
-  private $extensionDiscovery;
-
-  /**
-   * Array of Drupal namespaces.
-   *
-   * @var array
-   */
-  private $namespaces = [];
+class DrupalAutoloader extends DrupalAutoloaderBase {
 
   /**
    * Load in Drupal code from defined path.
@@ -143,6 +79,32 @@ class DrupalAutoloader {
       }
     }
 
+    $this->registerIncludeModuleFiles();
+    $this->registerIncludeThemeFiles();
+
+    if (class_exists(Drush::class)) {
+      $reflect = new \ReflectionClass(Drush::class);
+      if ($reflect->getFileName() !== FALSE) {
+        $levels = 2;
+        if (Drush::getMajorVersion() < 9) {
+          $levels = 3;
+        }
+        $drushDir = dirname($reflect->getFileName(), $levels);
+        /** @var \SplFileInfo $file */
+        foreach (Finder::findFiles('*.inc')->in($drushDir . '/includes') as $file) {
+          // phpcs:ignore PHPCS_SecurityAudit.Misc.IncludeMismatch.ErrMiscIncludeMismatchNoExt
+          require_once $file->getPathname();
+        }
+      }
+    }
+
+    $this->registerIncludeServicesFromYamls();
+  }
+
+  /**
+   * Helper for register() method to include module files.
+   */
+  private function registerIncludeModuleFiles() {
     foreach ($this->moduleData as $extension) {
       $this->loadExtension($extension);
 
@@ -177,6 +139,12 @@ class DrupalAutoloader {
         }
       }
     }
+  }
+
+  /**
+   * Helper for register() method to include theme files.
+   */
+  private function registerIncludeThemeFiles() {
     foreach ($this->themeData as $extension) {
       $this->loadExtension($extension);
       $theme_dir = $this->drupalRoot . '/' . $extension->getPath();
@@ -185,23 +153,14 @@ class DrupalAutoloader {
         $this->loadAndCatchErrors($theme_settings_file);
       }
     }
+  }
 
-    if (class_exists(Drush::class)) {
-      $reflect = new \ReflectionClass(Drush::class);
-      if ($reflect->getFileName() !== FALSE) {
-        $levels = 2;
-        if (Drush::getMajorVersion() < 9) {
-          $levels = 3;
-        }
-        $drushDir = dirname($reflect->getFileName(), $levels);
-        /** @var \SplFileInfo $file */
-        foreach (Finder::findFiles('*.inc')->in($drushDir . '/includes') as $file) {
-          // phpcs:ignore PHPCS_SecurityAudit.Misc.IncludeMismatch.ErrMiscIncludeMismatchNoExt
-          require_once $file->getPathname();
-        }
-      }
-    }
-
+  /**
+   * Helper for register() method to include services.
+   *
+   * @todo Fix this method not being properly used - see https://github.com/wunderio/code-quality/issues/96 for more info.
+   */
+  private function registerIncludeServicesFromYamls() {
     foreach ($this->serviceYamls as $extension => $serviceYaml) {
       $yaml = Yaml::parseFile($serviceYaml);
       // Weed out service files which only provide parameters.
@@ -244,149 +203,6 @@ class DrupalAutoloader {
         $this->serviceMap[$serviceId] = $serviceDefinition;
       }
     }
-  }
-
-  /**
-   * Load legacy includes.
-   */
-  protected function loadLegacyIncludes(): void {
-    /** @var \SplFileInfo $file */
-    foreach (Finder::findFiles('*.inc')->in($this->drupalRoot . '/core/includes') as $file) {
-      // phpcs:ignore PHPCS_SecurityAudit.Misc.IncludeMismatch.ErrMiscIncludeMismatchNoExt
-      require_once $file->getPathname();
-    }
-  }
-
-  /**
-   * Add core test namespaces.
-   */
-  protected function addTestNamespaces(): void {
-    $core_tests_dir = $this->drupalRoot . '/core/tests/Drupal';
-    $this->namespaces['Drupal\\BuildTests'] = $core_tests_dir . '/BuildTests';
-    $this->namespaces['Drupal\\FunctionalJavascriptTests'] = $core_tests_dir . '/FunctionalJavascriptTests';
-    $this->namespaces['Drupal\\FunctionalTests'] = $core_tests_dir . '/FunctionalTests';
-    $this->namespaces['Drupal\\KernelTests'] = $core_tests_dir . '/KernelTests';
-    $this->namespaces['Drupal\\Tests'] = $core_tests_dir . '/Tests';
-    $this->namespaces['Drupal\\TestSite'] = $core_tests_dir . '/TestSite';
-    $this->namespaces['Drupal\\TestTools'] = $core_tests_dir . '/TestTools';
-    $this->namespaces['Drupal\\Tests\\TestSuites'] = $this->drupalRoot . '/core/tests/TestSuites';
-  }
-
-  /**
-   * Add Drupal module namespaces.
-   */
-  protected function addModuleNamespaces(): void {
-    foreach ($this->moduleData as $module) {
-      $module_name = $module->getName();
-      $module_dir = $this->drupalRoot . '/' . $module->getPath();
-      $this->namespaces["Drupal\\$module_name"] = $module_dir . '/src';
-
-      // Extensions can have a \Drupal\Tests\extension namespace for test
-      // cases, traits, and other classes such
-      // as those that extend \Drupal\TestSite\TestSetupInterface.
-      // @see drupal_phpunit_get_extension_namespaces()
-      $module_test_dir = $module_dir . '/tests/src';
-      if (is_dir($module_test_dir)) {
-        $this->namespaces["Drupal\\Tests\\$module_name"] = $module_test_dir;
-      }
-
-      $servicesFileName = $module_dir . '/' . $module_name . '.services.yml';
-      if (file_exists($servicesFileName)) {
-        $this->serviceYamls[$module_name] = $servicesFileName;
-      }
-      $camelized = $this->camelize($module_name);
-      $name = "{$camelized}ServiceProvider";
-      $class = "Drupal\\{$module_name}\\{$name}";
-
-      $this->serviceClassProviders[$module_name] = $class;
-      $serviceId = "service_provider.$module_name.service_provider";
-      $this->serviceMap[$serviceId] = ['class' => $class];
-    }
-  }
-
-  /**
-   * Add Drupal theme namespaces.
-   */
-  protected function addThemeNamespaces(): void {
-    foreach ($this->themeData as $theme_name => $theme) {
-      $theme_dir = $this->drupalRoot . '/' . $theme->getPath();
-      $this->namespaces["Drupal\\$theme_name"] = $theme_dir . '/src';
-    }
-  }
-
-  /**
-   * Register PS4 namespaces.
-   *
-   * @param array $namespaces
-   *   An array of namespaces to load.
-   */
-  protected function registerPs4Namespaces(array $namespaces): void {
-    foreach ($namespaces as $prefix => $paths) {
-      if (is_array($paths)) {
-        foreach ($paths as $key => $value) {
-          $paths[$key] = $value;
-        }
-      }
-      $this->autoloader->addPsr4($prefix . '\\', $paths);
-    }
-  }
-
-  /**
-   * Loads in extensions (modules, themes, etc).
-   *
-   * Wrapper for \mglaman\PHPStanDrupal\Drupal\Extension->load().
-   *
-   * @param \mglaman\PHPStanDrupal\Drupal\Extension $extension
-   *   Extension object.
-   */
-  protected function loadExtension(Extension $extension): void {
-    try {
-      $extension->load();
-    }
-    catch (\Throwable $e) {
-      // Something prevented the extension file from loading.
-      // This can happen when drupal_get_path or drupal_get_filename are used
-      // outside the scope of a function.
-    }
-  }
-
-  /**
-   * Wrapper for require_once() that catches errors.
-   *
-   * @param string $path
-   *   Path to file.
-   */
-  protected function loadAndCatchErrors(string $path): void {
-    try {
-      // phpcs:ignore PHPCS_SecurityAudit.Misc.IncludeMismatch.ErrMiscIncludeMismatchNoExt
-      require_once $path;
-    }
-    catch (ContainerNotInitializedException $e) {
-      $path = str_replace(dirname($this->drupalRoot) . '/', '', $path);
-      // This can happen when drupal_get_path or drupal_get_filename are used
-      // outside the scope of a function.
-      @trigger_error("$path invoked the Drupal container outside of the scope of a function or class method. It was not loaded.", E_USER_WARNING);
-    }
-    catch (\Throwable $e) {
-      $path = str_replace(dirname($this->drupalRoot) . '/', '', $path);
-      // Something prevented the extension file from loading.
-      @trigger_error("$path failed loading due to {$e->getMessage()}", E_USER_WARNING);
-    }
-  }
-
-  /**
-   * Camelizes a string.
-   *
-   * @todo Should we use method from Symfony\Component\DependencyInjection\Container instead?
-   *
-   * @param string $id
-   *   A string to camelize.
-   *
-   * @return string
-   *   The camelized string.
-   */
-  protected function camelize(string $id): string {
-    return strtr(ucwords(strtr($id, ['_' => ' ', '.' => '_ ', '\\' => '_ '])), [' ' => '']);
   }
 
 }

--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Wunderio\GrumPHP\Drupal;
 
-use DrupalFinder\DrupalFinder;
+use DrupalFinder\DrupalFinderComposerRuntime;
 use Drush\Drush;
 use Nette\Utils\Finder;
 use PHPUnit\Framework\Test;
@@ -26,8 +26,7 @@ class DrupalAutoloader extends DrupalAutoloaderBase {
    *   Path to Drupal root.
    */
   public function register(string $drupalRoot): void {
-    $finder = new DrupalFinder();
-    $finder->locateRoot($drupalRoot);
+    $finder = new DrupalFinderComposerRuntime();
 
     $drupalRoot = $finder->getDrupalRoot();
     $drupalVendorRoot = $finder->getVendorDir();

--- a/src/Drupal/DrupalAutoloaderBase.php
+++ b/src/Drupal/DrupalAutoloaderBase.php
@@ -11,7 +11,7 @@ use mglaman\PHPStanDrupal\Drupal\Extension;
 /**
  * Drupal autoloader base class for allowing Psalm to scan code.
  *
- * Code re-used from https://github.com/mglaman/phpstan-drupal/blob/main/src/Drupal/DrupalAutoloader.php.
+ * This was split into 2 classes to code complexity would not be too high.
  */
 class DrupalAutoloaderBase {
 

--- a/src/Drupal/DrupalAutoloaderBase.php
+++ b/src/Drupal/DrupalAutoloaderBase.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wunderio\GrumPHP\Drupal;
+
+use Drupal\Core\DependencyInjection\ContainerNotInitializedException;
+use Nette\Utils\Finder;
+use mglaman\PHPStanDrupal\Drupal\Extension;
+
+/**
+ * Drupal autoloader base class for allowing Psalm to scan code.
+ *
+ * Code re-used from https://github.com/mglaman/phpstan-drupal/blob/main/src/Drupal/DrupalAutoloader.php.
+ */
+class DrupalAutoloaderBase {
+
+  /**
+   * Drupal autoloader.
+   *
+   * @var \Composer\Autoload\ClassLoader
+   */
+  protected $autoloader;
+
+  /**
+   * Path to Drupal root.
+   *
+   * @var string
+   */
+  protected $drupalRoot;
+
+  /**
+   * List of available modules.
+   *
+   * @var array
+   */
+  protected $moduleData = [];
+
+  /**
+   * List of available themes.
+   *
+   * @var array
+   */
+  protected $themeData = [];
+
+  /**
+   * Array of Drupal service mapping.
+   *
+   * @var array
+   */
+  protected $serviceMap = [];
+
+  /**
+   * Array of Drupal service yml files.
+   *
+   * @var array
+   */
+  protected $serviceYamls = [];
+
+  /**
+   * Array of service class providers.
+   *
+   * @var array
+   */
+  protected $serviceClassProviders = [];
+
+  /**
+   * ExtensionDiscovery object.
+   *
+   * @var \mglaman\PHPStanDrupal\Drupal\ExtensionDiscovery
+   */
+  protected $extensionDiscovery;
+
+  /**
+   * Array of Drupal namespaces.
+   *
+   * @var array
+   */
+  protected $namespaces = [];
+
+  /**
+   * Load legacy includes.
+   */
+  protected function loadLegacyIncludes(): void {
+    /** @var \SplFileInfo $file */
+    foreach (Finder::findFiles('*.inc')->in($this->drupalRoot . '/core/includes') as $file) {
+      // phpcs:ignore PHPCS_SecurityAudit.Misc.IncludeMismatch.ErrMiscIncludeMismatchNoExt
+      require_once $file->getPathname();
+    }
+  }
+
+  /**
+   * Add core test namespaces.
+   */
+  protected function addTestNamespaces(): void {
+    $core_tests_dir = $this->drupalRoot . '/core/tests/Drupal';
+    $this->namespaces['Drupal\\BuildTests'] = $core_tests_dir . '/BuildTests';
+    $this->namespaces['Drupal\\FunctionalJavascriptTests'] = $core_tests_dir . '/FunctionalJavascriptTests';
+    $this->namespaces['Drupal\\FunctionalTests'] = $core_tests_dir . '/FunctionalTests';
+    $this->namespaces['Drupal\\KernelTests'] = $core_tests_dir . '/KernelTests';
+    $this->namespaces['Drupal\\Tests'] = $core_tests_dir . '/Tests';
+    $this->namespaces['Drupal\\TestSite'] = $core_tests_dir . '/TestSite';
+    $this->namespaces['Drupal\\TestTools'] = $core_tests_dir . '/TestTools';
+    $this->namespaces['Drupal\\Tests\\TestSuites'] = $this->drupalRoot . '/core/tests/TestSuites';
+  }
+
+  /**
+   * Add Drupal module namespaces.
+   */
+  protected function addModuleNamespaces(): void {
+    foreach ($this->moduleData as $module) {
+      $module_name = $module->getName();
+      $module_dir = $this->drupalRoot . '/' . $module->getPath();
+      $this->namespaces["Drupal\\$module_name"] = $module_dir . '/src';
+
+      // Extensions can have a \Drupal\Tests\extension namespace for test
+      // cases, traits, and other classes such
+      // as those that extend \Drupal\TestSite\TestSetupInterface.
+      // @see drupal_phpunit_get_extension_namespaces()
+      $module_test_dir = $module_dir . '/tests/src';
+      if (is_dir($module_test_dir)) {
+        $this->namespaces["Drupal\\Tests\\$module_name"] = $module_test_dir;
+      }
+
+      $servicesFileName = $module_dir . '/' . $module_name . '.services.yml';
+      if (file_exists($servicesFileName)) {
+        $this->serviceYamls[$module_name] = $servicesFileName;
+      }
+      $camelized = $this->camelize($module_name);
+      $name = "{$camelized}ServiceProvider";
+      $class = "Drupal\\{$module_name}\\{$name}";
+
+      $this->serviceClassProviders[$module_name] = $class;
+      $serviceId = "service_provider.$module_name.service_provider";
+      $this->serviceMap[$serviceId] = ['class' => $class];
+    }
+  }
+
+  /**
+   * Add Drupal theme namespaces.
+   */
+  protected function addThemeNamespaces(): void {
+    foreach ($this->themeData as $theme_name => $theme) {
+      $theme_dir = $this->drupalRoot . '/' . $theme->getPath();
+      $this->namespaces["Drupal\\$theme_name"] = $theme_dir . '/src';
+    }
+  }
+
+  /**
+   * Register PS4 namespaces.
+   *
+   * @param array $namespaces
+   *   An array of namespaces to load.
+   */
+  protected function registerPs4Namespaces(array $namespaces): void {
+    foreach ($namespaces as $prefix => $paths) {
+      if (is_array($paths)) {
+        foreach ($paths as $key => $value) {
+          $paths[$key] = $value;
+        }
+      }
+      $this->autoloader->addPsr4($prefix . '\\', $paths);
+    }
+  }
+
+  /**
+   * Loads in extensions (modules, themes, etc).
+   *
+   * Wrapper for \mglaman\PHPStanDrupal\Drupal\Extension->load().
+   *
+   * @param \mglaman\PHPStanDrupal\Drupal\Extension $extension
+   *   Extension object.
+   */
+  protected function loadExtension(Extension $extension): void {
+    try {
+      $extension->load();
+    }
+    catch (\Throwable $e) {
+      // Something prevented the extension file from loading.
+      // This can happen when drupal_get_path or drupal_get_filename are used
+      // outside the scope of a function.
+    }
+  }
+
+  /**
+   * Wrapper for require_once() that catches errors.
+   *
+   * @param string $path
+   *   Path to file.
+   */
+  protected function loadAndCatchErrors(string $path): void {
+    try {
+      // phpcs:ignore PHPCS_SecurityAudit.Misc.IncludeMismatch.ErrMiscIncludeMismatchNoExt
+      require_once $path;
+    }
+    catch (ContainerNotInitializedException $e) {
+      $path = str_replace(dirname($this->drupalRoot) . '/', '', $path);
+      // This can happen when drupal_get_path or drupal_get_filename are used
+      // outside the scope of a function.
+      @trigger_error("$path invoked the Drupal container outside of the scope of a function or class method. It was not loaded.", E_USER_WARNING);
+    }
+    catch (\Throwable $e) {
+      $path = str_replace(dirname($this->drupalRoot) . '/', '', $path);
+      // Something prevented the extension file from loading.
+      @trigger_error("$path failed loading due to {$e->getMessage()}", E_USER_WARNING);
+    }
+  }
+
+  /**
+   * Camelizes a string.
+   *
+   * @todo Should we use method from Symfony\Component\DependencyInjection\Container instead?
+   *
+   * @param string $id
+   *   A string to camelize.
+   *
+   * @return string
+   *   The camelized string.
+   */
+  protected function camelize(string $id): string {
+    return strtr(ucwords(strtr($id, ['_' => ' ', '.' => '_ ', '\\' => '_ '])), [' ' => '']);
+  }
+
+}


### PR DESCRIPTION
## Description

2 years ago we had to remove code complexity checks https://github.com/wunderio/code-quality/pull/71/files#diff-368d327cbe54fd3c9d4537668316b016ca7aee4c2e09f60cca8d9c67f711d27eL15  when adding support for D9 for Code Quality. We were waiting for Drupal 10 to come out to add it back, but it seems there's a new package that can be used and there's no Symfony restriction on it https://github.com/TomasVotruba/cognitive-complexity

## Testing notes

1. Include this version of Code Quality

    `lando composer require wunderio/code-quality:dev-feature/72-Re-add-code-complexity --dev --with-all-dependencies`


2. Edit your local phpstan.neon file and add (use tabs)

```
	cognitive_complexity:
		class: 50
		function: 16
```


**OR** copy over the file from this version:

    cp vendor/wunderio/code-quality/config/phpstan.neon ./phpstan.neon

![image](https://github.com/wunderio/code-quality/assets/492375/d264549c-16e7-4142-92b2-f8dd6dd28d6b)


3. Update some file in your codebase,  make it lengthy, if's inside if's is good :) , or maybe just copy paste until it's like 100 lines long

**OR** 

Create file at `web/modules/custom/updates_file.php` (it needs to be under web/modules/custom/)
Ask **Copilot** To create the code.
`Create in PHP 10 foreaches inside each other in a function. Please write out each foreach.`

![image](https://github.com/wunderio/code-quality/assets/492375/0eca51f7-4e2c-41c6-975c-05ab1a293a8d)

4. Stage the file to GIT

    `git add web/modules/custom/updates_file.php`

Try to commit and see if the you see alert about cognitive complexity

    `git commit`

You should see something like this along the lines:

![image](https://github.com/wunderio/code-quality/assets/492375/41ad8512-3a10-4d31-8e92-257c24af76ae)
