### PR TITLE
Feature/wd 257 upgrade grumphp to v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "bin": ["bin/check_perms"],
     "require": {
         "symfony/polyfill-iconv": "^1",
-        "phpro/grumphp": "^1",
+        "phpro/grumphp": "^2.5",
         "drupal/coder": "^8",
         "phpcompatibility/php-compatibility": "^9.3",
         "pheromone/phpcs-security-audit": "^2.0",
@@ -44,10 +44,7 @@
         "dealerdirect/phpcodesniffer-composer-installer": "*",
         "mglaman/phpstan-drupal": "^1.1",
         "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
-        "vimeo/psalm": "^4",
-        "nette/finder": "^2.5",
-        "symfony/finder": "^4.4 || ^5.3 || ^6"
+        "phpstan/phpstan-deprecation-rules": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -9,11 +9,11 @@ grumphp:
     phpcs:
       run_on: ['src', 'tests']
     php_stan:
-     run_on: ['src']
-     configuration: phpstan.neon
+      run_on: ['src']
+      configuration: phpstan.neon
     yaml_lint: ~
     json_lint: ~
-    #phpunit: ~
+    phpunit: ~
     php_check_syntax: ~
     #psalm: ~
   extensions:

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -11,7 +11,7 @@ grumphp:
     #php_stan:
     #  run_on: ['src']
     #  configuration: phpstan.neon
-    #yaml_lint: ~
+    yaml_lint: ~
     #json_lint: ~
     #phpunit: ~
     #php_check_syntax: ~
@@ -23,6 +23,6 @@ grumphp:
     #- Wunderio\GrumPHP\Task\Ecs\EcsExtensionLoader
     - Wunderio\GrumPHP\Task\Phpcs\PhpcsExtensionLoader
     #- Wunderio\GrumPHP\Task\PhpStan\PhpStanExtensionLoader
-    #- Wunderio\GrumPHP\Task\YamlLint\YamlLintExtensionLoader
+    - Wunderio\GrumPHP\Task\YamlLint\YamlLintExtensionLoader
     #- Wunderio\GrumPHP\Task\JsonLint\JsonLintExtensionLoader
     #- Wunderio\GrumPHP\Task\Psalm\PsalmExtensionLoader

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -8,9 +8,9 @@ grumphp:
       run_on: ['src', 'tests']
     phpcs:
       run_on: ['src', 'tests']
-    #php_stan:
-    #  run_on: ['src']
-    #  configuration: phpstan.neon
+    php_stan:
+     run_on: ['src']
+     configuration: phpstan.neon
     yaml_lint: ~
     json_lint: ~
     #phpunit: ~
@@ -22,7 +22,7 @@ grumphp:
     #- Wunderio\GrumPHP\Task\CheckFilePermissions\CheckFilePermissionsExtensionLoader
     #- Wunderio\GrumPHP\Task\Ecs\EcsExtensionLoader
     - Wunderio\GrumPHP\Task\Phpcs\PhpcsExtensionLoader
-    #- Wunderio\GrumPHP\Task\PhpStan\PhpStanExtensionLoader
+    - Wunderio\GrumPHP\Task\PhpStan\PhpStanExtensionLoader
     - Wunderio\GrumPHP\Task\YamlLint\YamlLintExtensionLoader
     - Wunderio\GrumPHP\Task\JsonLint\JsonLintExtensionLoader
     #- Wunderio\GrumPHP\Task\Psalm\PsalmExtensionLoader

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -19,7 +19,7 @@ grumphp:
   extensions:
     - Wunderio\GrumPHP\Task\PhpCompatibility\PhpCompatibilityExtensionLoader
     - Wunderio\GrumPHP\Task\PhpCheckSyntax\PhpCheckSyntaxExtensionLoader
-    #- Wunderio\GrumPHP\Task\CheckFilePermissions\CheckFilePermissionsExtensionLoader
+    - Wunderio\GrumPHP\Task\CheckFilePermissions\CheckFilePermissionsExtensionLoader
     - Wunderio\GrumPHP\Task\Ecs\EcsExtensionLoader
     - Wunderio\GrumPHP\Task\Phpcs\PhpcsExtensionLoader
     - Wunderio\GrumPHP\Task\PhpStan\PhpStanExtensionLoader

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -12,7 +12,7 @@ grumphp:
     #  run_on: ['src']
     #  configuration: phpstan.neon
     yaml_lint: ~
-    #json_lint: ~
+    json_lint: ~
     #phpunit: ~
     #php_check_syntax: ~
     #psalm: ~
@@ -24,5 +24,5 @@ grumphp:
     - Wunderio\GrumPHP\Task\Phpcs\PhpcsExtensionLoader
     #- Wunderio\GrumPHP\Task\PhpStan\PhpStanExtensionLoader
     - Wunderio\GrumPHP\Task\YamlLint\YamlLintExtensionLoader
-    #- Wunderio\GrumPHP\Task\JsonLint\JsonLintExtensionLoader
+    - Wunderio\GrumPHP\Task\JsonLint\JsonLintExtensionLoader
     #- Wunderio\GrumPHP\Task\Psalm\PsalmExtensionLoader

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -14,7 +14,7 @@ grumphp:
     yaml_lint: ~
     json_lint: ~
     #phpunit: ~
-    #php_check_syntax: ~
+    php_check_syntax: ~
     #psalm: ~
   extensions:
     - Wunderio\GrumPHP\Task\PhpCompatibility\PhpCompatibilityExtensionLoader

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -20,7 +20,7 @@ grumphp:
     - Wunderio\GrumPHP\Task\PhpCompatibility\PhpCompatibilityExtensionLoader
     - Wunderio\GrumPHP\Task\PhpCheckSyntax\PhpCheckSyntaxExtensionLoader
     #- Wunderio\GrumPHP\Task\CheckFilePermissions\CheckFilePermissionsExtensionLoader
-    #- Wunderio\GrumPHP\Task\Ecs\EcsExtensionLoader
+    - Wunderio\GrumPHP\Task\Ecs\EcsExtensionLoader
     - Wunderio\GrumPHP\Task\Phpcs\PhpcsExtensionLoader
     - Wunderio\GrumPHP\Task\PhpStan\PhpStanExtensionLoader
     - Wunderio\GrumPHP\Task\YamlLint\YamlLintExtensionLoader

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -4,8 +4,8 @@ grumphp:
     failed: ~
     succeeded: ~
   tasks:
-    #php_compatibility:
-    #  run_on: ['src', 'tests']
+    php_compatibility:
+      run_on: ['src', 'tests']
     phpcs:
       run_on: ['src', 'tests']
     #php_stan:
@@ -17,7 +17,7 @@ grumphp:
     #php_check_syntax: ~
     #psalm: ~
   extensions:
-    #- Wunderio\GrumPHP\Task\PhpCompatibility\PhpCompatibilityExtensionLoader
+    - Wunderio\GrumPHP\Task\PhpCompatibility\PhpCompatibilityExtensionLoader
     - Wunderio\GrumPHP\Task\PhpCheckSyntax\PhpCheckSyntaxExtensionLoader
     #- Wunderio\GrumPHP\Task\CheckFilePermissions\CheckFilePermissionsExtensionLoader
     #- Wunderio\GrumPHP\Task\Ecs\EcsExtensionLoader

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -4,25 +4,25 @@ grumphp:
     failed: ~
     succeeded: ~
   tasks:
-    php_compatibility:
-      run_on: ['src', 'tests']
+    #php_compatibility:
+    #  run_on: ['src', 'tests']
     phpcs:
       run_on: ['src', 'tests']
-    php_stan:
-      run_on: ['src']
-      configuration: phpstan.neon
-    yaml_lint: ~
-    json_lint: ~
-    phpunit: ~
-    php_check_syntax: ~
-    psalm: ~
+    #php_stan:
+    #  run_on: ['src']
+    #  configuration: phpstan.neon
+    #yaml_lint: ~
+    #json_lint: ~
+    #phpunit: ~
+    #php_check_syntax: ~
+    #psalm: ~
   extensions:
-    - Wunderio\GrumPHP\Task\PhpCompatibility\PhpCompatibilityExtensionLoader
+    #- Wunderio\GrumPHP\Task\PhpCompatibility\PhpCompatibilityExtensionLoader
     - Wunderio\GrumPHP\Task\PhpCheckSyntax\PhpCheckSyntaxExtensionLoader
-    - Wunderio\GrumPHP\Task\CheckFilePermissions\CheckFilePermissionsExtensionLoader
-    - Wunderio\GrumPHP\Task\Ecs\EcsExtensionLoader
+    #- Wunderio\GrumPHP\Task\CheckFilePermissions\CheckFilePermissionsExtensionLoader
+    #- Wunderio\GrumPHP\Task\Ecs\EcsExtensionLoader
     - Wunderio\GrumPHP\Task\Phpcs\PhpcsExtensionLoader
-    - Wunderio\GrumPHP\Task\PhpStan\PhpStanExtensionLoader
-    - Wunderio\GrumPHP\Task\YamlLint\YamlLintExtensionLoader
-    - Wunderio\GrumPHP\Task\JsonLint\JsonLintExtensionLoader
-    - Wunderio\GrumPHP\Task\Psalm\PsalmExtensionLoader
+    #- Wunderio\GrumPHP\Task\PhpStan\PhpStanExtensionLoader
+    #- Wunderio\GrumPHP\Task\YamlLint\YamlLintExtensionLoader
+    #- Wunderio\GrumPHP\Task\JsonLint\JsonLintExtensionLoader
+    #- Wunderio\GrumPHP\Task\Psalm\PsalmExtensionLoader

--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Wunderio\GrumPHP\Drupal;
 
-use DrupalFinder\DrupalFinder;
 use Drupal\Core\DependencyInjection\ContainerNotInitializedException;
+use DrupalFinder\DrupalFinder;
 use Drush\Drush;
+use mglaman\PHPStanDrupal\Drupal\Extension;
+use mglaman\PHPStanDrupal\Drupal\ExtensionDiscovery;
 use Nette\Utils\Finder;
 use PHPUnit\Framework\Test;
 use Symfony\Component\Yaml\Yaml;
-use mglaman\PHPStanDrupal\Drupal\Extension;
-use mglaman\PHPStanDrupal\Drupal\ExtensionDiscovery;
 
 /**
  * Drupal autoloader for allowing Psalm to scan code.

--- a/src/Task/AbstractExternalExtensionLoader.php
+++ b/src/Task/AbstractExternalExtensionLoader.php
@@ -18,54 +18,10 @@ use Symfony\Component\Yaml\Yaml;
  */
 abstract class AbstractExternalExtensionLoader implements ExtensionInterface {
 
-  /**
-   * Name.
-   *
-   * @var string
-   */
-  public $name;
-
-  /**
-   * Construction arguments.
-   *
-   * @var array
-   */
-  public $arguments;
-
-  /**
-   * Task class.
-   *
-   * @var string
-   */
-  public $class;
-
-  /**
-   * AbstractExternalExtensionLoader constructor.
-   */
-  public function __construct() {
-    $tasks = Yaml::parseFile(__DIR__ . '/tasks.yml');
+  public function imports(): iterable {
     $class_name = str_replace('ExtensionLoader', '', static::class);
-    $this->class = $class_name . 'Task';
-    $default_configuration = $tasks['default'];
-    unset($default_configuration['name']);
-    $configurations = $tasks[$this->class] ?? $default_configuration;
-    $class_name = explode('\\', $class_name);
-    $default_name = strtolower(preg_replace('/\B([A-Z])/', '_$1', end($class_name)));
-    $this->name = $configurations['name'] ?? $default_name;
-    $this->arguments = $configurations['arguments'] ?? $default_configuration['arguments'];
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function load(ContainerBuilder $container): void {
-    $task = $container->register('task.' . $this->name, $this->class);
-    if (!empty($this->arguments)) {
-      foreach ($this->arguments as $argument) {
-        $task->addArgument(new Reference($argument));
-      }
-    }
-    $task->addTag('grumphp.task', ['task' => $this->name]);
+    $class_exploded = explode('\\', $class_name);
+    yield dirname(__DIR__).'/Task/'. end($class_exploded) . '/services.yaml';
   }
 
 }

--- a/src/Task/AbstractExternalExtensionLoader.php
+++ b/src/Task/AbstractExternalExtensionLoader.php
@@ -1,13 +1,10 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Wunderio\GrumPHP\Task;
 
 use GrumPHP\Extension\ExtensionInterface;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\Yaml\Yaml;
 
 /**
  * Class AbstractExternalExtensionLoader.
@@ -18,10 +15,13 @@ use Symfony\Component\Yaml\Yaml;
  */
 abstract class AbstractExternalExtensionLoader implements ExtensionInterface {
 
+  /**
+   * {@inheritdoc}
+   */
   public function imports(): iterable {
     $class_name = str_replace('ExtensionLoader', '', static::class);
     $class_exploded = explode('\\', $class_name);
-    yield dirname(__DIR__).'/Task/'. end($class_exploded) . '/services.yaml';
+    yield dirname(__DIR__) . '/Task/' . end($class_exploded) . '/services.yaml';
   }
 
 }

--- a/src/Task/AbstractLintTask.php
+++ b/src/Task/AbstractLintTask.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Wunderio\GrumPHP\Task;
 

--- a/src/Task/AbstractMultiPathProcessingTask.php
+++ b/src/Task/AbstractMultiPathProcessingTask.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Wunderio\GrumPHP\Task;
 

--- a/src/Task/AbstractProcessingTask.php
+++ b/src/Task/AbstractProcessingTask.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Wunderio\GrumPHP\Task;
 

--- a/src/Task/AbstractSinglePathProcessingTask.php
+++ b/src/Task/AbstractSinglePathProcessingTask.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Wunderio\GrumPHP\Task;
 

--- a/src/Task/CheckFilePermissions/CheckFilePermissionsTask.php
+++ b/src/Task/CheckFilePermissions/CheckFilePermissionsTask.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Wunderio\GrumPHP\Task\CheckFilePermissions;
 

--- a/src/Task/CheckFilePermissions/services.yaml
+++ b/src/Task/CheckFilePermissions/services.yaml
@@ -1,0 +1,8 @@
+services:
+   Wunderio\GrumPHP\Task\CheckFilePermissions\CheckFilePermissionsTask:
+    class: Wunderio\GrumPHP\Task\CheckFilePermissions\CheckFilePermissionsTask
+    arguments:
+      - '@process_builder'
+      - '@formatter.raw_process'
+    tags:
+      - {name: grumphp.task, task: check_file_permissions}

--- a/src/Task/ConfigurableTaskInterface.php
+++ b/src/Task/ConfigurableTaskInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Wunderio\GrumPHP\Task;
 

--- a/src/Task/ConfigurableTaskTrait.php
+++ b/src/Task/ConfigurableTaskTrait.php
@@ -4,6 +4,7 @@ namespace Wunderio\GrumPHP\Task;
 
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Runner\TaskResult;
+use GrumPHP\Task\Config\ConfigOptionsResolver;
 use GrumPHP\Task\Config\TaskConfigInterface;
 use GrumPHP\Task\Context\ContextInterface;
 use GrumPHP\Task\Context\GitPreCommitContext;
@@ -81,7 +82,7 @@ trait ConfigurableTaskTrait {
   /**
    * {@inheritdoc}
    */
-  public static function getConfigurableOptions(): OptionsResolver {
+  public static function getConfigurableOptions(): ConfigOptionsResolver {
     // Get configurable options.
     $tasks = Yaml::parseFile(__DIR__ . '/tasks.yml');
     $default_configuration = $tasks['default'];
@@ -100,7 +101,7 @@ trait ConfigurableTaskTrait {
       $resolver->addAllowedTypes($option_name, $option['allowed_types']);
     }
 
-    return $resolver;
+    return ConfigOptionsResolver::fromOptionsResolver($resolver);
   }
 
   /**

--- a/src/Task/Ecs/EcsTask.php
+++ b/src/Task/Ecs/EcsTask.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Wunderio\GrumPHP\Task\Ecs;
 

--- a/src/Task/Ecs/services.yaml
+++ b/src/Task/Ecs/services.yaml
@@ -1,0 +1,8 @@
+services:
+   Wunderio\GrumPHP\Task\Ecs\EcsTask:
+    class: Wunderio\GrumPHP\Task\Ecs\EcsTask
+    arguments:
+      - '@process_builder'
+      - '@formatter.raw_process'
+    tags:
+      - {name: grumphp.task, task: ecs}

--- a/src/Task/JsonLint/JsonLintTask.php
+++ b/src/Task/JsonLint/JsonLintTask.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Wunderio\GrumPHP\Task\JsonLint;
 

--- a/src/Task/JsonLint/services.yaml
+++ b/src/Task/JsonLint/services.yaml
@@ -1,0 +1,7 @@
+services:
+   Wunderio\GrumPHP\Task\JsonLint\JsonLintTask:
+    class: Wunderio\GrumPHP\Task\JsonLint\JsonLintTask
+    arguments:
+      - '@linter.jsonlint'
+    tags:
+      - {name: grumphp.task, task: json_lint}

--- a/src/Task/LintTaskInterface.php
+++ b/src/Task/LintTaskInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Wunderio\GrumPHP\Task;
 

--- a/src/Task/MultiPathArgumentsBuilderInterface.php
+++ b/src/Task/MultiPathArgumentsBuilderInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Wunderio\GrumPHP\Task;
 

--- a/src/Task/PhpCheckSyntax/PhpCheckSyntaxTask.php
+++ b/src/Task/PhpCheckSyntax/PhpCheckSyntaxTask.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Wunderio\GrumPHP\Task\PhpCheckSyntax;
 

--- a/src/Task/PhpCheckSyntax/services.yaml
+++ b/src/Task/PhpCheckSyntax/services.yaml
@@ -1,4 +1,3 @@
-# my-extension.yaml
 services:
   Wunderio\GrumPHP\Task\PhpCheckSyntax\PhpCheckSyntaxTask:
     class: Wunderio\GrumPHP\Task\PhpCheckSyntax\PhpCheckSyntaxTask

--- a/src/Task/PhpCheckSyntax/services.yaml
+++ b/src/Task/PhpCheckSyntax/services.yaml
@@ -1,0 +1,9 @@
+# my-extension.yaml
+services:
+  Wunderio\GrumPHP\Task\PhpCheckSyntax\PhpCheckSyntaxTask:
+    class: Wunderio\GrumPHP\Task\PhpCheckSyntax\PhpCheckSyntaxTask
+    arguments:
+      - '@process_builder'
+      - '@formatter.raw_process'
+    tags:
+      - {name: grumphp.task, task: php_check_syntax}

--- a/src/Task/PhpCompatibility/PhpCompatibilityTask.php
+++ b/src/Task/PhpCompatibility/PhpCompatibilityTask.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Wunderio\GrumPHP\Task\PhpCompatibility;
 

--- a/src/Task/PhpCompatibility/services.yaml
+++ b/src/Task/PhpCompatibility/services.yaml
@@ -1,0 +1,8 @@
+services:
+   Wunderio\GrumPHP\Task\PhpCompatibility\PhpCompatibilityTask:
+    class: Wunderio\GrumPHP\Task\PhpCompatibility\PhpCompatibilityTask
+    arguments:
+      - '@process_builder'
+      - '@formatter.raw_process'
+    tags:
+      - {name: grumphp.task, task: php_compatibility}

--- a/src/Task/PhpStan/PhpStanTask.php
+++ b/src/Task/PhpStan/PhpStanTask.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Wunderio\GrumPHP\Task\PhpStan;
 

--- a/src/Task/PhpStan/services.yaml
+++ b/src/Task/PhpStan/services.yaml
@@ -1,0 +1,8 @@
+services:
+   Wunderio\GrumPHP\Task\PhpStan\PhpStanTask:
+    class: Wunderio\GrumPHP\Task\PhpStan\PhpStanTask
+    arguments:
+      - '@process_builder'
+      - '@formatter.raw_process'
+    tags:
+      - {name: grumphp.task, task: php_stan}

--- a/src/Task/Phpcs/PhpcsTask.php
+++ b/src/Task/Phpcs/PhpcsTask.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Wunderio\GrumPHP\Task\Phpcs;
 

--- a/src/Task/Phpcs/services.yaml
+++ b/src/Task/Phpcs/services.yaml
@@ -1,0 +1,8 @@
+services:
+  Wunderio\GrumPHP\Task\Phpcs\PhpcsTask:
+    class: Wunderio\GrumPHP\Task\Phpcs\PhpcsTask
+    arguments:
+      - '@process_builder'
+      - '@formatter.phpcs'
+    tags:
+      - {name: grumphp.task, task: phpcs}

--- a/src/Task/Psalm/PsalmTask.php
+++ b/src/Task/Psalm/PsalmTask.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Wunderio\GrumPHP\Task\Psalm;
 

--- a/src/Task/SinglePathArgumentsBuilderInterface.php
+++ b/src/Task/SinglePathArgumentsBuilderInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Wunderio\GrumPHP\Task;
 

--- a/src/Task/YamlLint/YamlLintTask.php
+++ b/src/Task/YamlLint/YamlLintTask.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Wunderio\GrumPHP\Task\YamlLint;
 

--- a/src/Task/YamlLint/services.yaml
+++ b/src/Task/YamlLint/services.yaml
@@ -1,0 +1,7 @@
+services:
+   Wunderio\GrumPHP\Task\YamlLint\YamlLintTask:
+    class: Wunderio\GrumPHP\Task\YamlLint\YamlLintTask
+    arguments:
+      - '@linter.yamllint'
+    tags:
+      - {name: grumphp.task, task: yaml_lint}

--- a/src/Task/tasks.yml
+++ b/src/Task/tasks.yml
@@ -29,7 +29,7 @@ Wunderio\GrumPHP\Task\CheckFilePermissions\CheckFilePermissionsTask:
         - '/node_modules/'
         - '/core/'
         - '/libraries/'
-        - '/modules/contrib/'
+        - '/modules\/contrib/'
       allowed_types: ['array']
     extensions:
       defaults: ['sh']

--- a/src/test2.sh
+++ b/src/test2.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+set -e
+set -u
+export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
+
+#
+# Filter files by mime.
+#
+# Usage: acquire_files_mime 'text/x-shellscript' file1 file2 fileN
+#
+function acquire_files_mime {
+  local files="${@:2}"
+  local mime="$1"
+  local res=""
+
+  for file in $files
+  do
+    local valid_file=$(file --mime-type "$file" \
+    | grep -E ':\s*'"$mime"'$' \
+    | sed -e 's/:.*//')
+    if [ ! -z "$valid_file" ]
+    then
+      res="$res$valid_file
+"
+    fi
+  done
+  echo "$res"
+}
+
+#
+# Functiont to check file permissions.
+#
+# Usage: check_perms 755 file_name
+#
+function check_perms {
+  local perms_expect="$1"
+  local file="$2"
+  local result=""
+
+  case "$(uname -s)" in
+    Darwin*) # mac
+      stat_flags='-f %p'
+      perms_expect="100$perms_expect"
+      ;;
+    Linux*|*) # linux or the rest
+      stat_flags='-c %a'
+      ;;
+  esac
+
+  perms_current="$(stat $stat_flags "$file")"
+  if [ "$perms_current" != "$perms_expect" ]; then
+    result="$result
+File: $file
+Current permissions:  $perms_current
+Expected permissions: $perms_expect
+-"
+  fi
+
+  printf "$result"
+}
+
+#
+# Check for shell script permissions.
+#
+function check_sh_perms {
+  local files="$@"
+  local res=""
+  local files_sh=$(acquire_files_mime 'text/x-shellscript' "$files")
+
+
+  for file in $files_sh
+  do
+    res="$res$(check_perms 755 "$file")"
+  done
+
+  if [ ! -z "$res" ]
+  then
+    echo "Fix file permissions for the following shell scripts:"
+    echo "$res"
+    exit 1
+  else
+    exit 0
+  fi
+}
+
+check_sh_perms "$@"

--- a/tests/AbstractExternalExtensionLoaderTest.php
+++ b/tests/AbstractExternalExtensionLoaderTest.php
@@ -5,7 +5,7 @@
  * Tests covering AbstractExternalExtensionLoader.
  */
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 use Wunderio\GrumPHP\Task\AbstractExternalExtensionLoader;

--- a/tests/AbstractExternalExtensionLoaderTest.php
+++ b/tests/AbstractExternalExtensionLoaderTest.php
@@ -18,15 +18,16 @@ use Wunderio\GrumPHP\Task\AbstractExternalExtensionLoader;
 final class AbstractExternalExtensionLoaderTest extends TestCase {
 
   /**
-   * Test class constructor.
+   * Test imports method.
    *
-   * @covers \Wunderio\GrumPHP\Task\AbstractExternalExtensionLoader::__construct
+   * @covers \Wunderio\GrumPHP\Task\AbstractExternalExtensionLoader::import()
    */
-  public function testSetsConfigurationFromYaml(): void {
+  public function testImports(): void {
     $customLoader = new CustomTestExtensionLoader();
-    $this->assertEquals('custom_test', $customLoader->name);
-    $this->assertEquals(['process_builder', 'formatter.raw_process'], $customLoader->arguments);
-    $this->assertEquals('CustomTestTask', $customLoader->class);
+    $imports = $customLoader->imports();
+
+    $expected_path = dirname(__DIR__) . '/src/Task/CustomTest/services.yaml';
+    $this->assertEquals([$expected_path], iterator_to_array($imports));
   }
 
 }

--- a/tests/AbstractLintTaskTest.php
+++ b/tests/AbstractLintTaskTest.php
@@ -5,7 +5,7 @@
  * Tests covering AbstractLintTask.
  */
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Collection\LintErrorsCollection;

--- a/tests/AbstractMultiPathProcessingTaskTest.php
+++ b/tests/AbstractMultiPathProcessingTaskTest.php
@@ -5,7 +5,7 @@
  * Tests covering AbstractMultiPathProcessingTask.
  */
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 use GrumPHP\Collection\ProcessArgumentsCollection;
 use GrumPHP\Formatter\ProcessFormatterInterface;

--- a/tests/AbstractProcessingTaskTest.php
+++ b/tests/AbstractProcessingTaskTest.php
@@ -5,7 +5,7 @@
  * Tests covering AbstractProcessingTask.
  */
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 use GrumPHP\Formatter\ProcessFormatterInterface;
 use GrumPHP\Process\ProcessBuilder;

--- a/tests/AbstractSinglePathProcessingTaskTest.php
+++ b/tests/AbstractSinglePathProcessingTaskTest.php
@@ -5,7 +5,7 @@
  * Tests covering AbstractSinglePathProcessingTask.
  */
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Collection\ProcessArgumentsCollection;

--- a/tests/CheckFilePermissions/CheckFilePermissionsTaskTest.php
+++ b/tests/CheckFilePermissions/CheckFilePermissionsTaskTest.php
@@ -5,7 +5,7 @@
  * Tests covering CheckFilePermissionsTask.
  */
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Collection\ProcessArgumentsCollection;

--- a/tests/ConfigurableTaskTraitTest.php
+++ b/tests/ConfigurableTaskTraitTest.php
@@ -5,7 +5,7 @@
  * Tests covering ConfigurableTaskTrait.
  */
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Runner\TaskResult;

--- a/tests/ConfigurableTaskTraitTest.php
+++ b/tests/ConfigurableTaskTraitTest.php
@@ -48,7 +48,7 @@ final class ConfigurableTaskTraitTest extends TestCase {
       ->getMockForTrait();
     $stub->configure();
     $resolver = $stub->getConfigurableOptions();
-    $options = array_flip($resolver->getDefinedOptions());
+    $options = array_flip(array_keys($resolver->resolve([])));
     $this->assertArrayHasKey('ignore_patterns', $options);
     $this->assertArrayHasKey('extensions', $options);
     $this->assertArrayHasKey('run_on', $options);

--- a/tests/ContextRunTraitTest.php
+++ b/tests/ContextRunTraitTest.php
@@ -5,7 +5,7 @@
  * Tests covering ContextRunTrait.
  */
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Task\Context\GitCommitMsgContext;

--- a/tests/Ecs/EcsTaskTest.php
+++ b/tests/Ecs/EcsTaskTest.php
@@ -5,7 +5,7 @@
  * Tests covering EcsTask.
  */
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Collection\ProcessArgumentsCollection;

--- a/tests/JsonLint/JsonLintTaskTest.php
+++ b/tests/JsonLint/JsonLintTaskTest.php
@@ -5,7 +5,7 @@
  * Tests covering JsonLintTask.
  */
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 use GrumPHP\Linter\Json\JsonLinter;
 use GrumPHP\Task\Config\TaskConfigInterface;

--- a/tests/PhpCheckSyntax/PhpCheckSyntaxTaskTest.php
+++ b/tests/PhpCheckSyntax/PhpCheckSyntaxTaskTest.php
@@ -5,7 +5,7 @@
  * Tests covering PhpCheckSyntaxTask.
  */
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 use GrumPHP\Collection\ProcessArgumentsCollection;
 use GrumPHP\Formatter\ProcessFormatterInterface;

--- a/tests/PhpCompatibility/PhpCompatibilityTaskTest.php
+++ b/tests/PhpCompatibility/PhpCompatibilityTaskTest.php
@@ -5,7 +5,7 @@
  * Tests covering PhpCompatibilityTask.
  */
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 use GrumPHP\Collection\FilesCollection;
 use GrumPHP\Collection\ProcessArgumentsCollection;

--- a/tests/PhpStan/PhpStanTaskTest.php
+++ b/tests/PhpStan/PhpStanTaskTest.php
@@ -5,7 +5,7 @@
  * Tests covering PhpstanCheckDeprecationTask.
  */
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 use GrumPHP\Collection\ProcessArgumentsCollection;
 use GrumPHP\Formatter\ProcessFormatterInterface;

--- a/tests/Phpcs/PhpcsTaskTest.php
+++ b/tests/Phpcs/PhpcsTaskTest.php
@@ -5,7 +5,7 @@
  * Tests covering PhpcsTask.
  */
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 use GrumPHP\Collection\ProcessArgumentsCollection;
 use GrumPHP\Formatter\ProcessFormatterInterface;

--- a/tests/YamlLint/YamlLintTaskTest.php
+++ b/tests/YamlLint/YamlLintTaskTest.php
@@ -5,7 +5,7 @@
  * Tests covering YamlLintTask.
  */
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 use GrumPHP\Linter\Yaml\YamlLinter;
 use GrumPHP\Task\Config\TaskConfigInterface;


### PR DESCRIPTION
## Description

This updates phpro/grumphp to ^2.5.

## Testing

1. Disable psalm for now:
![image](https://github.com/wunderio/code-quality/assets/492375/de22a48e-897e-4c22-a819-c37cd774312a)



2. Require this branch:

`composer require wunderio/code-quality:dev-feature/WD-257-Upgrade-GrumPHP-to-v2 --dev --with-all-dependencies`

3. Try to commit some bad code or run 

`lando grumphp run`
