### PR TITLE
#99 Fix PHP Stan error with DrupalAutoloader.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
         "dealerdirect/phpcodesniffer-composer-installer": "*",
         "mglaman/phpstan-drupal": "^1.1",
         "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan-deprecation-rules": "^1.0"
+        "phpstan/phpstan-deprecation-rules": "^1.0",
+        "webflo/drupal-finder": "^1.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/Drupal/DrupalAutoloader.php
+++ b/src/Drupal/DrupalAutoloader.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Wunderio\GrumPHP\Drupal;
 
 use Drupal\Core\DependencyInjection\ContainerNotInitializedException;
-use DrupalFinder\DrupalFinder;
+use DrupalFinder\DrupalFinderComposerRuntime;
 use Drush\Drush;
 use mglaman\PHPStanDrupal\Drupal\Extension;
 use mglaman\PHPStanDrupal\Drupal\ExtensionDiscovery;
@@ -90,8 +90,7 @@ class DrupalAutoloader {
    *   Path to Drupal root.
    */
   public function register(string $drupalRoot): void {
-    $finder = new DrupalFinder();
-    $finder->locateRoot($drupalRoot);
+    $finder = new DrupalFinderComposerRuntime();
 
     $drupalRoot = $finder->getDrupalRoot();
     $drupalVendorRoot = $finder->getVendorDir();


### PR DESCRIPTION
## Overview

There's failure in main branch tests https://app.circleci.com/pipelines/github/wunderio/code-quality/257/workflows/ba91db7e-cc48-45a4-ac72-ce8cc7530c7d/jobs/300?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary
 
This PR fixes it.

## Screenshots

![image](https://github.com/wunderio/code-quality/assets/492375/b5a56c46-084a-479a-9f07-e6c091db726f)

![image](https://github.com/wunderio/code-quality/assets/492375/87ab2bd6-5d7c-4d2b-a7ef-b1738bd65236)


## Testing

1. Require this branch with:
`composer require wunderio/code-quality:dev-hotfix/99-fix-php_stan-error-with-DrupalAutoloader --dev --with-all-dependencies`
