### PR TITLE
#81 Change PHP refererence in readme and in php_compatibility task to 8.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This repository currently has the following checks:
 
 * Shell script exec bits - [check_file_permissions](src/Task/CheckFilePermissions/README.md)
 * PHP Drupal CS and PHP Code security  - [phpcs](src/Task/Phpcs/README.md)
-* PHP 8.0 Compatibility - [php_compatibility](src/Task/PhpCompatibility/README.md)
+* PHP 8.1 Compatibility - [php_compatibility](src/Task/PhpCompatibility/README.md)
 * PHP syntax - [php_check_syntax](src/Task/PhpCheckSyntax/README.md)
 * Cognitive complexity and other ecs sniffs - [ecs](src/Task/Ecs/README.md)
 * Yaml syntax - [yaml_lint](src/Task/YamlLint/README.md)
@@ -27,7 +27,7 @@ This repository currently has the following checks:
 ## Pre-requisites
 
 * Composer
-* PHP >= 7.3
+* PHP >= 8.1
 
 ## Installation
 

--- a/src/Task/PhpCompatibility/README.md
+++ b/src/Task/PhpCompatibility/README.md
@@ -14,7 +14,7 @@ parameters:
                 - '/libraries/'
             extensions: ['php', 'inc', 'module', 'install', 'theme']
             run_on: ['.']
-            testVersion: '8.0'
+            testVersion: '8.1'
             standard: 'PHPCompatibility'
             parallel: 20
     extensions:

--- a/src/Task/tasks.yml
+++ b/src/Task/tasks.yml
@@ -99,7 +99,7 @@ Wunderio\GrumPHP\Task\PhpCompatibility\PhpCompatibilityTask:
       defaults: ['.']
       allowed_types: ['array']
     testVersion:
-      defaults: '8.0'
+      defaults: '8.1'
       allowed_types: ['string']
     standard:
       defaults: 'PHPCompatibility'

--- a/tests/PhpCompatibility/PhpCompatibilityTaskTest.php
+++ b/tests/PhpCompatibility/PhpCompatibilityTaskTest.php
@@ -47,7 +47,7 @@ final class PhpCompatibilityTaskTest extends TestCase {
     $stub->method('getConfig')->willReturn($taskConfig);
     $taskConfig->method('getOptions')->willReturn([
       'standard' => 'php-compatibility.xm',
-      'testVersion' => '8.0',
+      'testVersion' => '8.1',
       'extensions' => ['php'],
       'run_on' => ['.'],
       'ignore_patterns' => ['/vendor/'],


### PR DESCRIPTION
## Overview

Very small PR - php_compatibility task's default PHP version is still at 8.0. Also in readme we're still saying 7.3 is required, although the tool does only run in PHP 8.1. On top of these, PHP 8.0 is EOL.

## Testing

No extra testing is needed as the test is really minimal and the test that runs with this PR passes.
