### PR TITLE
#106 Change yaml, json and check_file_permissions task default paths

### DIFF
--- a/src/Task/tasks.yml
+++ b/src/Task/tasks.yml
@@ -35,7 +35,7 @@ Wunderio\GrumPHP\Task\CheckFilePermissions\CheckFilePermissionsTask:
       defaults: ['sh']
       allowed_types: ['array']
     run_on:
-      defaults: ['.']
+      defaults: ['web/modules/custom', 'web/themes/custom', 'scripts']
       allowed_types: ['array']
 Wunderio\GrumPHP\Task\Ecs\EcsTask:
   options:

--- a/src/Task/tasks.yml
+++ b/src/Task/tasks.yml
@@ -210,7 +210,7 @@ Wunderio\GrumPHP\Task\YamlLint\YamlLintTask:
       defaults: ['yaml', 'yml']
       allowed_types: ['array']
     run_on:
-      defaults: ['.']
+      defaults: ['web/modules/custom', 'web/themes/custom']
       allowed_types: ['array']
     object_support:
       defaults: false
@@ -241,7 +241,7 @@ Wunderio\GrumPHP\Task\JsonLint\JsonLintTask:
       defaults: ['json', 'lock']
       allowed_types: ['array']
     run_on:
-      defaults: ['.']
+      defaults: ['web/modules/custom', 'web/themes/custom']
       allowed_types: ['array']
     detect_key_conflicts:
       defaults: false


### PR DESCRIPTION
## Overview

Currently the defaults are quite loose which is [.] folder. There was issue in one of our first project changing to Code Quality 3.x because of that - test just died. After setting the paths for all tasks, tests went through https://github.com/wunderio/client-fi-tre3-content-machine/pull/1468/commits/e1fef73e79b52e73612c75bb9c6e3c88836b14e8

Instead of fixing every project one by one, this PR changes the defaults in base config. This means if task in project is set up with defaults (~), then the issue is gone.

## Screenshots

![image](https://github.com/wunderio/code-quality/assets/492375/fc11d613-2c9b-486d-97e2-9f5bc8435544)


## Testing

1. Include this version of Code Quality

    `lando composer require wunderio/code-quality:dev-hotfix/106-Change-yaml-and-json-task-default-paths --dev`

2. Run Grumphp to check everything works

`lando grumph run`


3. Also, here's the project PR https://github.com/wunderio/client-fi-tre3-content-machine/pull/1468 where I  changed to this version and reverted grumphp changes.