### PR TITLE
QAG-24: Upgrade wunderio/code-quality Sonar scanner setup to v10.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - run: >-
           cd /home/circleci/project/ &&
           sonar-scanner -Dsonar.host.url=$SONAR_HOST
-          -Dsonar.login=$SONAR_TOKEN
+          -Dsonar.token=$SONAR_TOKEN
           -Dsonar.php.coverage.reportPaths=/home/circleci/project/coverage.xml
           -Dsonar.projectKey=code-quality
           -Dsonar.sources=/home/circleci/project/src


### PR DESCRIPTION
Changes:

- sonar.login is deprecated use sonar.token instead

