### PR TITLE
GH-119: Add module-scoped phpunit GrumPHP task

### DIFF
--- a/src/Task/PhpUnitModules/PhpUnitModulesExtensionLoader.php
+++ b/src/Task/PhpUnitModules/PhpUnitModulesExtensionLoader.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wunderio\GrumPHP\Task\PhpUnitModules;
+
+use Wunderio\GrumPHP\Task\AbstractExternalExtensionLoader;
+
+/**
+ * Registers the PhpUnitModules task in GrumPHP.
+ */
+class PhpUnitModulesExtensionLoader extends AbstractExternalExtensionLoader {}
+

--- a/src/Task/PhpUnitModules/PhpUnitModulesTask.php
+++ b/src/Task/PhpUnitModules/PhpUnitModulesTask.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Wunderio\GrumPHP\Task\PhpUnitModules;
+
+use GrumPHP\Collection\ProcessArgumentsCollection;
+use GrumPHP\Runner\TaskResult;
+use GrumPHP\Runner\TaskResultInterface;
+use GrumPHP\Task\Context\ContextInterface;
+use Wunderio\GrumPHP\Task\AbstractMultiPathProcessingTask;
+
+/**
+ * Class PhpUnitModulesTask.
+ *
+ * Runs phpunit only for modules affected by the current context.
+ */
+class PhpUnitModulesTask extends AbstractMultiPathProcessingTask {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function run(ContextInterface $context): TaskResultInterface {
+    $paths = $this->getPathsOrResult($context, $this->getConfig()->getOptions(), $this);
+    if ($paths instanceof TaskResultInterface) {
+      return $paths;
+    }
+
+    $modules = [];
+    foreach ($paths as $file) {
+      $path = (string) $file;
+
+      // Only consider custom modules. Contrib modules are intentionally ignored.
+      if (!str_starts_with($path, 'web/modules/custom/')) {
+        continue;
+      }
+
+      if (preg_match('#^(web/modules/custom/[^/]+)#', $path, $matches)) {
+        $modules[$matches[1]] = $matches[1];
+      }
+    }
+
+    // No affected modules -> nothing to run.
+    if (!$modules) {
+      return TaskResult::createSkipped($this, $context);
+    }
+
+    $process = $this->processBuilder->buildProcess($this->buildArguments($modules));
+    $process->run();
+
+    return $this->getTaskResult($process, $context);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildArguments(iterable $modules): ProcessArgumentsCollection {
+    // Use the local DDEV phpunit wrapper.
+    $arguments = $this->processBuilder->createArgumentsForCommand('ddev');
+    $arguments->add('phpunit');
+
+    foreach ($modules as $modulePath) {
+      $arguments->add($modulePath);
+    }
+
+    return $arguments;
+  }
+
+}
+

--- a/src/Task/PhpUnitModules/services.yaml
+++ b/src/Task/PhpUnitModules/services.yaml
@@ -1,0 +1,9 @@
+services:
+  Wunderio\GrumPHP\Task\PhpUnitModules\PhpUnitModulesTask:
+    class: Wunderio\GrumPHP\Task\PhpUnitModules\PhpUnitModulesTask
+    arguments:
+      - '@process_builder'
+      - '@formatter.raw_process'
+    tags:
+      - { name: grumphp.task, task: php_unit_modules }
+

--- a/src/Task/tasks.yml
+++ b/src/Task/tasks.yml
@@ -281,3 +281,21 @@ Wunderio\GrumPHP\Task\Psalm\PsalmTask:
     show_info:
       defaults: false
       allowed_types: ['bool']
+
+Wunderio\GrumPHP\Task\PhpUnitModules\PhpUnitModulesTask:
+  is_file_specific: true
+  options:
+    ignore_patterns:
+      defaults:
+        - '/vendor/'
+        - '/node_modules/'
+        - '/core/'
+        - '/libraries/'
+        - '/contrib/'
+      allowed_types: ['array']
+    extensions:
+      defaults: ['php', 'inc', 'module', 'install', 'theme']
+      allowed_types: ['array']
+    run_on:
+      defaults: ['web/modules/custom']
+      allowed_types: ['array']


### PR DESCRIPTION
- introduced PhpUnitModules GrumPHP task that discovers affected custom modules from the current context
- wired PhpUnitModules task to run phpunit via ddev only for changed custom modules
- added task configuration defaults (paths, ignore patterns, extensions) to tasks.yml

Refs: src/Task/PhpUnitModules/PhpUnitModulesTask.php, src/Task/PhpUnitModules/PhpUnitModulesExtensionLoader.php, src/Task/PhpUnitModules/services.yaml, src/Task/tasks.yml

## Overview



## Screenshots



## Testing


